### PR TITLE
Prevent Zulip container from crashing after restart with disabled HTTPS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -141,8 +141,13 @@ setConfigurationValue() {
 nginxConfiguration() {
     echo "Executing nginx configuration ..."
     if [ "$DISABLE_HTTPS" == "True" ] || [ "$DISABLE_HTTPS" == "true" ]; then
+      if [ -e /opt/files/nginx/zulip-enterprise-http ]
+      then
         echo "Disabling https in nginx."
         mv -f /opt/files/nginx/zulip-enterprise-http /etc/nginx/sites-enabled/zulip-enterprise
+      else
+        echo "Https already disabled in nginx."
+      fi
     fi
     sed -i "s/worker_processes .*/worker_processes $NGINX_WORKERS;/g" /etc/nginx/nginx.conf
     sed -i "s/client_max_body_size .*/client_max_body_size $NGINX_MAX_UPLOAD_SIZE;/g" /etc/nginx/nginx.conf


### PR DESCRIPTION
Disabling HTTPS currently works fine but only the first time the container starts.

The issue is that `set -e` is set: https://github.com/zulip/docker-zulip/blob/283c23fd0b33fd66f007469619e2cdc6c0ef956c/entrypoint.sh#L7 , which makes `entrypoint.sh` exit immediately if any command it runs exits with a non-zero status.

With `DISABLE_HTTPS`, the entrypoint does this

https://github.com/zulip/docker-zulip/blob/283c23fd0b33fd66f007469619e2cdc6c0ef956c/entrypoint.sh#L145

each time the container starts, but `mv` returns `1` even with `-f` when the file it's trying to move doesn't exist, which is the case after the 1st run because it got moved on the first run. Basically this line only works on the first run, and crashes the entrypoint after this.

This PR should fix this.