### PR TITLE
Add certbot support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get -q dist-upgrade -y && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY entrypoint.sh /sbin/entrypoint.sh
+COPY certbot-deploy-hook /sbin/certbot-deploy-hook
 
 VOLUME ["$DATA_DIR"]
 EXPOSE 80 443

--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ which you need to encode in the YAML file.  For example,
   comma-separated list of the backend names
   (E.g. `"EmailAuthBackend,GitHubAuthBackend"`).
 
-**SSL Certificates**.  By default, the image will generate a
-  self-signed cert.  We
-  [will soon also support certbot](https://github.com/zulip/docker-zulip/issues/120)
-  for this, just like we do in normal Zulip installations
-  (contributions welcome!).
+**SSL Certificates**.  By default, the image will generate a self-signed cert.
+You can set `SSL_CERTIFICATE_GENERATION: "certbot"` within `docker-compose.yml`
+to enable automatically-renewed Let's Encrypt certificates.  By using certbot
+here, you are agreeing to the [Let's Encrypt
+ToS](https://community.letsencrypt.org/tos).
 
 You can also provide an SSL certificate for your Zulip server by
 putting it in `/opt/docker/zulip/zulip/certs/` (by default, the

--- a/certbot-deploy-hook
+++ b/certbot-deploy-hook
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+backup() {
+    if [ -e "$1" ]; then
+        # If the user is setting up our automatic certbot-management on a
+        # system that already has certs for Zulip, use some extra caution
+        # to keep the old certs available. This naming is consistent with Zulip's
+        # own setup-certbot backups.
+        mv -f --backup=numbered "$1" "$1".setup-certbot || true
+    fi
+}
+
+source_cert_dir=/etc/letsencrypt/live/"$SETTING_EXTERNAL_HOST"
+dest_cert_dir="$DATA_DIR"/certs
+
+# Persist the certs to the data directory.
+backup "$dest_cert_dir"/zulip.key
+backup "$dest_cert_dir"/zulip.combined-chain.crt
+cp -f "$source_cert_dir"/privkey.pem "$dest_cert_dir"/zulip.key
+cp -f "$source_cert_dir"/fullchain.pem "$dest_cert_dir"/zulip.combined-chain.crt
+
+# Ensure nginx can find them.
+ln -nsf "$dest_cert_dir"/zulip.key /etc/ssl/private/zulip.key
+ln -nsf "$dest_cert_dir"/zulip.combined-chain.crt /etc/ssl/certs/zulip.combined-chain.crt
+
+# Restart various services so the new certs can be used.
+supervisorctl restart nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       DB_HOST_PORT: "5432"
       DB_USER: "zulip"
       SSL_CERTIFICATE_GENERATION: "self-signed"
+      ZULIP_CERTBOT_DEPLOY_HOOK: /sbin/certbot-deploy-hook
       SETTING_MEMCACHED_LOCATION: "memcached:11211"
       SETTING_RABBITMQ_HOST: "rabbitmq"
       SETTING_REDIS_HOST: "redis"


### PR DESCRIPTION
The task is to generate a self-signed cert so Zulip can be started, then to wait until Zulip is up before using certbot to generate new certs. Zulip needs to be up so it can meet certbot's challenge. Using a deploy hook (relevant Zulip PR here: https://github.com/zulip/zulip/pull/10015), certs are persisted in the data directory. The same applies to renewal.

This closes #120.