### PR TITLE
docker: enables building the Zulip image with a custom CA bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@
 FROM ubuntu:xenial-20171114
 LABEL maintainer="Alexander Trost <galexrt@googlemail.com>"
 
-ENV ZULIP_GIT_URL="https://github.com/zulip/zulip.git" \
-    ZULIP_GIT_REF="master"
+ARG ZULIP_GIT_URL=https://github.com/zulip/zulip.git
+ARG ZULIP_GIT_REF=master
+ARG CUSTOM_CA_CERTIFICATES=
+
+SHELL ["/bin/sh", "-xc"]
 
 # First, we setup working locales
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
@@ -43,6 +46,7 @@ RUN /bin/bash -c "source /srv/zulip-py3-venv/bin/activate && ./tools/build-relea
 FROM ubuntu:xenial-20171114
 LABEL maintainer="Alexander Trost <galexrt@googlemail.com>"
 
+ARG CUSTOM_CA_CERTIFICATES=
 ENV DATA_DIR="/data" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \

--- a/README.md
+++ b/README.md
@@ -256,6 +256,23 @@ Since that process for running management commands is a pain, we recommend
 
 [wrapper-tool]: https://github.com/zulip/docker-zulip/wiki/Running-Management-Commands
 
+### Using a custom certificate bundle
+
+If you are sitting behind a custom CA and want to build the Zulip
+image yourself special care is required.
+
+Zulip installs packages via `yarn` and `pip` and these need to be
+configured to use these certificates. You will need to get your
+certificate bundle into the docker image, either by adding a `COPY`
+somewhere or by replacing the `FROM`s with your custom ubuntu image
+that includes your bundle. The recommended way is to have your own
+base image which has your bundle ready at the default
+`/etc/ssl/certs/ca-certificates.crt`.
+
+The next and last step is to set up the `CUSTOM_CA_CERTIFICATES`
+argument in `docker-compose.yml` to point to your CA bundle.
+At this point you are ready to build Zulip.
+
 ## Running a Zulip server with Kubernetes
 
 A Kubernetes pod file is in the `kubernetes/` folder; you can run it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ services:
     image: "quay.io/galexrt/zulip:1.8.1-0"
     build:
       context: .
+      args:
+        # Use these if you want to download zulip from a different repo/branch
+        # ZULIP_GIT_URL:
+        # ZULIP_GIT_REF:
+        # Set this up if you plan to use your own CA certificate bundle for building
+        # CUSTOM_CA_CERTIFICATES:
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
I had a hard time building the Zulip image because we have a custom certificate in the chain. This PR along with an accompanying one in the main Zulip repository allow the user to build a docker image with a custom CA bundle. See readme update for details.