### PR TITLE
docker: pull the images to avoid building Zulip on first try

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ can provide a `settings.py` file and a `zulip-secrets.conf` file in
 You can boot your Zulip installation with:
 
 ```
+docker-compose pull
 docker-compose up
 ```
 
@@ -220,6 +221,8 @@ directory first).
 If you hit `Ctrl-C`, that will stop your Zulip server cluster.  If
 you'd prefer to have the containers run in the background, you can use
 `docker-compose up -d`.
+
+If you want to build the Zulip image yourself run `docker-compose build`.
 
 ### Connecting to your Zulip server
 


### PR DESCRIPTION
I updated the docker compose steps to first pull all images. Otherwise the Zulip image gets built which isn't needed for everyone. It also comes as a better first experience for the users as it takes less time and *just works*