### PR TITLE
docker: change zulip ENVs to ARGs for easier updating

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 FROM ubuntu:xenial-20171114
 LABEL maintainer="Alexander Trost <galexrt@googlemail.com>"
 
-ENV ZULIP_GIT_URL="https://github.com/zulip/zulip.git" \
-    ZULIP_GIT_REF="master"
+ARG ZULIP_GIT_URL=https://github.com/zulip/zulip.git
+ARG ZULIP_GIT_REF=master
 
 # First, we setup working locales
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,10 @@ services:
     image: "quay.io/galexrt/zulip:1.8.1-0"
     build:
       context: .
+      args:
+        # Change these if you want to download zulip from a different repo/branch
+        ZULIP_GIT_URL: https://github.com/zulip/zulip.git
+        ZULIP_GIT_REF: master
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
This way only the compose file needs to be touched which is more in line with
other configuration options