### PR TITLE
Increase zulip nofile limit to 40000 soft, 50000 hard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,3 +62,7 @@ services:
       # SETTING_PUSH_NOTIFICATION_BOUNCER_URL: 'https://push.zulipchat.com'
     volumes:
       - '/opt/docker/zulip/zulip:/data:rw'
+    ulimits:
+      nofile:
+        soft: 40000
+        hard: 50000


### PR DESCRIPTION
To match zulip/puppet/zulip/files/limits.conf, zulip/puppet/zulip/files/supervisor/supervisord.conf. Otherwise we inherit the Docker daemon’s limits, which are too small when Docker is installed as a snap.