### PR TITLE
Fix /etc/cron.d/autobackup; shell script cleanup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -283,7 +283,7 @@ autoBackupConfiguration() {
         echo "Auto backup is disabled. Continuing."
         return 0
     fi
-    echo "MAILTO=""\n$AUTO_BACKUP_INTERVAL cd /;/entrypoint.sh app:backup" > /etc/cron.d/autobackup
+    printf 'MAILTO=""\n%s cd /;/entrypoint.sh app:backup' "$AUTO_BACKUP_INTERVAL" > /etc/cron.d/autobackup
     echo "Auto backup enabled."
 }
 initialConfiguration() {


### PR DESCRIPTION
The previous code wrote

    MAILTO=\n30 3 * * * cd /;/entrypoint.sh app:backup

(with a literal backslash n) to /etc/cron.d/autobackup. This would have been caught by ShellCheck, so also clean up the code to fix all ShellCheck warnings.