### PR TITLE
Complain if backups directory is empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -456,7 +456,7 @@ appBackup() {
 }
 appRestore() {
     echo "Starting restore process ..."
-    if [ "$(ls -A "$DATA_DIR/backups/")" ]; then
+    if [ -z "$(ls -A $DATA_DIR/backups)" ]; then
         echo "No backups to restore found in \"$DATA_DIR/backups/\"."
         echo "Restore process failed. Exiting."
         exit 1


### PR DESCRIPTION
Currently this conditional results in `exit 1` when the backups
directory isn't empty.  This change flips the logic to complain 
when there are no backup files which, based on the error message, 
is the intended result.