### PR TITLE
[do not merge] Revert "entrypoint.sh: Fix ShellCheck warning introduced by #199."

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -456,7 +456,7 @@ appBackup() {
 }
 appRestore() {
     echo "Starting restore process ..."
-    if [ -z "$(ls -A "$DATA_DIR/backups/")" ]; then
+    if [ -z "$(ls -A $DATA_DIR/backups)" ]; then
         echo "No backups to restore found in \"$DATA_DIR/backups/\"."
         echo "Restore process failed. Exiting."
         exit 1


### PR DESCRIPTION
This intentionally reintroduces a ShellCheck warning to test that the new CircleCI setup will catch it.