### PR TITLE
Switch zulip-postgresql tag from latest to 10.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   database:
-    image: 'zulip/zulip-postgresql'
+    image: 'zulip/zulip-postgresql:10'
     environment:
       POSTGRES_DB: 'zulip'
       POSTGRES_USER: 'zulip'


### PR DESCRIPTION
I’ve [added a `10` tag](https://hub.docker.com/r/zulip/zulip-postgresql/tags) to `zulip-postgresql`, current pointing to the same image as `latest`.  Since upgrading to a new major version requires a manual migration, we shouldn’t encourage it to happen automatically.