### PR TITLE
Change specific LDAP overrides in entrypoint to match #11715 issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -253,6 +253,7 @@ zulipConfiguration() {
         # Zulip settings.py / zproject specific overrides here
         if [ "$setting_key" = "AUTH_LDAP_CONNECTION_OPTIONS" ] || \
            [ "$setting_key" = "AUTH_LDAP_USER_SEARCH" ] || \
+           [ "$setting_key" = "AUTH_LDAP_REVERSE_EMAIL_SEARCH" ] || \
            [ "$setting_key" = "AUTH_LDAP_USER_ATTR_MAP" ] || \
            { [ "$setting_key" = "LDAP_APPEND_DOMAIN" ] && [ "$setting_var" = "None" ]; } || \
            [ "$setting_key" = "SECURE_PROXY_SSL_HEADER" ] || \


### PR DESCRIPTION
Zulip repository has closed [issue #11715 ](https://github.com/zulip/zulip/issues/11715)with new settings variables and one should be the array.
Added AUTH_LDAP_REVERSE_EMAIL_SEARCH as an array into entrypoint.sh file