### PR TITLE
Enable authentication for memcached and Redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /home/zulip
 # You can specify these in docker-compose.yml or with
 #   docker build --build-args "ZULIP_GIT_REF=git_branch_name" .
 ARG ZULIP_GIT_URL=https://github.com/zulip/zulip.git
-ARG ZULIP_GIT_REF=2.1.1
+ARG ZULIP_GIT_REF=2.1.2
 
 RUN git clone "$ZULIP_GIT_URL" && \
     cd zulip && \

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This is a container image for running [Zulip](https://zulipchat.com)
 ([Github](https://github.com/zulip/zulip)) in
 [production][prod-overview]. Image available from:
 
-* [**Docker Hub**](https://hub.docker.com/r/zulip/docker-zulip) (`docker pull zulip/docker-zulip:2.1.1-0`)
+* [**Docker Hub**](https://hub.docker.com/r/zulip/docker-zulip) (`docker pull zulip/docker-zulip:2.1.2-0`)
 
-Current Zulip version: `2.1.1`
-Current Docker image version: `2.1.1-0`
+Current Zulip version: `2.1.2`
+Current Docker image version: `2.1.2-0`
 
 Project status: **Experimental**.  The core Zulip community recently
 adopted this project, and hasn't yet cleaned it up to our

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ production traffic, you need to also set these:
   your data!).
 * `RABBITMQ_DEFAULT_PASS` and `SECRETS_rabbitmq_password` are similar,
   just for the RabbitMQ container.
+* `MEMCACHED_PASSWORD` and `SECRETS_memcached_password` are similar,
+  just for the memcached container.
 * `SECRETS_secret_key` should be a long (e.g. 50 characters), random
   string.  This value is important to keep secret and constant over
   time, since it is used to (among other things) sign login cookies

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ production traffic, you need to also set these:
   just for the RabbitMQ container.
 * `MEMCACHED_PASSWORD` and `SECRETS_memcached_password` are similar,
   just for the memcached container.
+* `REDIS_PASSWORD` and `SECRETS_redis_password` are similar, just for
+  the Redis container.
 * `SECRETS_secret_key` should be a long (e.g. 50 characters), random
   string.  This value is important to keep secret and constant over
   time, since it is used to (among other things) sign login cookies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,17 @@ services:
     volumes:
       - '/opt/docker/zulip/rabbitmq:/var/lib/rabbitmq:rw'
   redis:
-    image: 'quay.io/sameersbn/redis:latest'
+    image: 'redis:alpine'
+    command:
+      - 'sh'
+      - '-euc'
+      - |
+        echo "requirepass '$$REDIS_PASSWORD'" > /etc/redis.conf
+        exec redis-server /etc/redis.conf
+    environment:
+      REDIS_PASSWORD: 'REPLACE_WITH_SECURE_REDIS_PASSWORD'
     volumes:
-      - '/opt/docker/zulip/redis:/var/lib/redis:rw'
+      - '/opt/docker/zulip/redis:/data:rw'
   zulip:
     image: 'zulip/docker-zulip:2.1.2-0'
     build:
@@ -61,10 +69,11 @@ services:
       SETTING_REDIS_HOST: 'redis'
       SECRETS_email_password: '123456789'
       # These should match RABBITMQ_DEFAULT_PASS, POSTGRES_PASSWORD,
-      # and MEMCACHED_PASSWORD above.
+      # MEMCACHED_PASSWORD, and REDIS_PASSWORD above.
       SECRETS_rabbitmq_password: 'REPLACE_WITH_SECURE_RABBITMQ_PASSWORD'
       SECRETS_postgres_password: 'REPLACE_WITH_SECURE_POSTGRES_PASSWORD'
       SECRETS_memcached_password: 'REPLACE_WITH_SECURE_MEMCACHED_PASSWORD'
+      SECRETS_redis_password: 'REPLACE_WITH_SECURE_REDIS_PASSWORD'
       SECRETS_secret_key: 'REPLACE_WITH_SECURE_SECRET_KEY'
       SETTING_EXTERNAL_HOST: 'localhost.localdomain'
       SETTING_ZULIP_ADMINISTRATOR: 'admin@example.com'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,18 @@ services:
     volumes:
       - '/opt/docker/zulip/postgresql/data:/var/lib/postgresql/data:rw'
   memcached:
-    image: 'quay.io/sameersbn/memcached:latest'
+    image: 'memcached:alpine'
+    command:
+      - 'sh'
+      - '-euc'
+      - |
+        echo 'mech_list: plain' > "$$SASL_CONF_PATH"
+        echo "zulip@$$HOSTNAME:$$MEMCACHED_PASSWORD" > "$$MEMCACHED_SASL_PWDB"
+        exec memcached -S
+    environment:
+      SASL_CONF_PATH: '/home/memcache/memcached.conf'
+      MEMCACHED_SASL_PWDB: '/home/memcache/memcached-sasl-db'
+      MEMCACHED_PASSWORD: 'REPLACE_WITH_SECURE_MEMCACHED_PASSWORD'
     restart: always
   rabbitmq:
     image: 'rabbitmq:3.7.7'
@@ -49,9 +60,11 @@ services:
       SETTING_RABBITMQ_HOST: 'rabbitmq'
       SETTING_REDIS_HOST: 'redis'
       SECRETS_email_password: '123456789'
-      # These should match POSTGRES_PASSWORD and RABBITMQ_DEFAULT_PASS.
+      # These should match RABBITMQ_DEFAULT_PASS, POSTGRES_PASSWORD,
+      # and MEMCACHED_PASSWORD above.
       SECRETS_rabbitmq_password: 'REPLACE_WITH_SECURE_RABBITMQ_PASSWORD'
       SECRETS_postgres_password: 'REPLACE_WITH_SECURE_POSTGRES_PASSWORD'
+      SECRETS_memcached_password: 'REPLACE_WITH_SECURE_MEMCACHED_PASSWORD'
       SECRETS_secret_key: 'REPLACE_WITH_SECURE_SECRET_KEY'
       SETTING_EXTERNAL_HOST: 'localhost.localdomain'
       SETTING_ZULIP_ADMINISTRATOR: 'admin@example.com'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,13 @@ services:
     volumes:
       - '/opt/docker/zulip/redis:/var/lib/redis:rw'
   zulip:
-    image: 'zulip/docker-zulip:2.1.1-0'
+    image: 'zulip/docker-zulip:2.1.2-0'
     build:
       context: .
       args:
         # Change these if you want to build zulip from a different repo/branch
         ZULIP_GIT_URL: https://github.com/zulip/zulip.git
-        ZULIP_GIT_REF: 2.1.1
+        ZULIP_GIT_REF: 2.1.2
         # Set this up if you plan to use your own CA certificate bundle for building
         # CUSTOM_CA_CERTIFICATES:
     ports:

--- a/kubernetes/zulip-rc.yml
+++ b/kubernetes/zulip-rc.yml
@@ -62,7 +62,7 @@ spec:
           - name: postgresql-persistent-storage
             mountPath: /var/lib/postgresql
       - name: zulip
-        image: zulip/docker-zulip:2.1.1-0
+        image: zulip/docker-zulip:2.1.2-0
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
This requires zulip/zulip#13682. Don’t merge this until after that is released and the version here is bumped.