### PR TITLE
Fix date format string; fix temporary backup directory validation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -440,17 +440,17 @@ appManagePy() {
 }
 appBackup() {
     echo "Starting backup process ..."
-    if [ -d "/tmp/backup-$(date "%D-%H-%M-%S")" ]; then
-        echo "Temporary backup folder for \"$(date "%D-%H-%M-%S")\" already exists. Aborting."
+    local BACKUP_FOLDER
+    BACKUP_FOLDER="/tmp/backup-$(date "+%D-%H-%M-%S")"
+    if [ -d "$BACKUP_FOLDER" ]; then
+        echo "Temporary backup folder \"$BACKUP_FOLDER\" already exists. Aborting."
         echo "Backup process failed. Exiting."
         exit 1
     fi
-    local BACKUP_FOLDER
-    BACKUP_FOLDER="/tmp/backup-$(date "%D-%H-%M-%S")"
     mkdir -p "$BACKUP_FOLDER"
     waitingForDatabase
     pg_dump -h "$DB_HOST" -p "$DB_HOST_PORT" -U "$DB_USER" "$DB_NAME" > "$BACKUP_FOLDER/database-postgres.sql"
-    tar -zcvf "$DATA_DIR/backups/backup-$(date "%D-%H-%M-%S").tar.gz" "$BACKUP_FOLDER/"
+    tar -zcvf "$DATA_DIR/backups/backup-$(date "+%D-%H-%M-%S").tar.gz" "$BACKUP_FOLDER/"
     rm -r "${BACKUP_FOLDER:?}/"
     echo "Backup process succeeded."
     exit 0


### PR DESCRIPTION
`date`'s format string must start with `+`.

The second fix is not so critical, but it can happen that the directory name for backup can change after the check (in `if`) and before the actual directory creation (in `mkdir`).