### PR TITLE
provision: replaced --production-travis with --build-release-tarball-only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /home/zulip/zulip
 ARG CUSTOM_CA_CERTIFICATES
 
 # Finally, we provision the development environment and build a release tarball
-RUN ./tools/provision --production-travis
+RUN ./tools/provision --build-release-tarball-only
 RUN . /srv/zulip-py3-venv/bin/activate && \
     ./tools/build-release-tarball docker && \
     mv /tmp/tmp.*/zulip-server-docker.tar.gz /tmp/zulip-server-docker.tar.gz


### PR DESCRIPTION
Fixes [https://github.com/zulip/docker-zulip/issues/256](https://github.com/zulip/docker-zulip/issues/256)
I think `ci/dockercloud ` is failing as this is not fixed in 2.1.4 branch.