### PR TITLE
Add postgres port to entrypoint config script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -215,6 +215,7 @@ secretsConfiguration() {
 databaseConfiguration() {
     echo "Setting database configuration ..."
     setConfigurationValue "REMOTE_POSTGRES_HOST" "$DB_HOST" "$SETTINGS_PY" "string"
+    setConfigurationValue "REMOTE_POSTGRES_PORT" "$DB_HOST_PORT" "$SETTINGS_PY" "string"
     setConfigurationValue "REMOTE_POSTGRES_SSLMODE" "$REMOTE_POSTGRES_SSLMODE" "$SETTINGS_PY" "string"
     # The password will be set in secretsConfiguration
     echo "Database configuration succeeded."


### PR DESCRIPTION
Add PostgreSQL port to entrypoint.sh config script (without it the container cannot be used with an existing PostgreSQL instance on a port other than 5432).