### PR TITLE
entrypoint: fix broken automatic backups

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -442,17 +442,17 @@ appManagePy() {
 }
 appBackup() {
     echo "Starting backup process ..."
-    if [ -d "/tmp/backup-$(date "%D-%H-%M-%S")" ]; then
-        echo "Temporary backup folder for \"$(date "%D-%H-%M-%S")\" already exists. Aborting."
+    if [ -d "/tmp/backup-$(date "+%F-%H-%M-%S")" ]; then
+        echo "Temporary backup folder for \"$(date "+%F-%H-%M-%S")\" already exists. Aborting."
         echo "Backup process failed. Exiting."
         exit 1
     fi
     local BACKUP_FOLDER
-    BACKUP_FOLDER="/tmp/backup-$(date "%D-%H-%M-%S")"
+    BACKUP_FOLDER="/tmp/backup-$(date "+%F-%H-%M-%S")"
     mkdir -p "$BACKUP_FOLDER"
     waitingForDatabase
-    pg_dump -h "$DB_HOST" -p "$DB_HOST_PORT" -U "$DB_USER" "$DB_NAME" > "$BACKUP_FOLDER/database-postgres.sql"
-    tar -zcvf "$DATA_DIR/backups/backup-$(date "%D-%H-%M-%S").tar.gz" "$BACKUP_FOLDER/"
+    PGPASSWORD="${SECRETS_postgres_password?}" pg_dump -h "$DB_HOST" -p "$DB_HOST_PORT" -U "$DB_USER" "$DB_NAME" > "$BACKUP_FOLDER/database-postgres.sql"
+    tar -zcvf "$DATA_DIR/backups/backup-$(date "+%F-%H-%M-%S").tar.gz" "$BACKUP_FOLDER/"
     rm -r "${BACKUP_FOLDER:?}/"
     echo "Backup process succeeded."
     exit 0


### PR DESCRIPTION
The scheduled database backups, that run by default using a cron timer, have not worked for a while. This seemed to be for 2 reasons: 
- Firstly the date command was not used properly, since both the '+' for the format was missing and %D should be %F (since the slashes produced by %D create new folders due to the usage in the script).
- Secondly, the password was not passed on to `pg_dump`. This resulted in it not being able to run from the cron timer.

This PR fixes both those things :)

I have seen plans to drop this backup system in favor of the integrated one, but for the time being it would make sense to at least have this backup function operational?