### PR TITLE
Update ubuntu base to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Zulip development environment image and use
 # tools/build-release-tarball to generate a production release tarball
 # from the provided Git ref.
-FROM ubuntu:18.04 as base
+FROM ubuntu:20.04 as base
 
 # Set up working locales and upgrade the base image
 ENV LANG="C.UTF-8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,9 +48,15 @@ services:
     volumes:
       - '/opt/docker/zulip/redis:/data:rw'
   zulip:
+    image: 'zulip/docker-zulip:3.3-0'
     build:
       context: .
-      dockerfile: Dockerfile
+      args:
+        # Change these if you want to build zulip from a different repo/branch
+        ZULIP_GIT_URL: https://github.com/zulip/zulip.git
+        ZULIP_GIT_REF: 3.3
+        # Set this up if you plan to use your own CA certificate bundle for building
+        # CUSTOM_CA_CERTIFICATES:
     ports:
       - '80:80'
       - '443:443'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,15 +48,9 @@ services:
     volumes:
       - '/opt/docker/zulip/redis:/data:rw'
   zulip:
-    image: 'zulip/docker-zulip:3.3-0'
     build:
       context: .
-      args:
-        # Change these if you want to build zulip from a different repo/branch
-        ZULIP_GIT_URL: https://github.com/zulip/zulip.git
-        ZULIP_GIT_REF: 3.3
-        # Set this up if you plan to use your own CA certificate bundle for building
-        # CUSTOM_CA_CERTIFICATES:
+      dockerfile: Dockerfile
     ports:
       - '80:80'
       - '443:443'


### PR DESCRIPTION
`su` is run in setup scripts (ex. `entrypoint.sh`) and requires the [linux capability](https://man7.org/linux/man-pages/man7/capabilities.7.html) `CAP_AUDIT_WRITE` in ubuntu 18.04. As a result, `su zulip -c ...` fails with `su: system error`. 

This is fixed in ubuntu 20.04 (thanks @andersk for finding!). 

Testing:
- I ran this locally using docker/docker compose using [this commit](https://github.com/zulip/docker-zulip/commit/c91459dc2fb025f09930d7c9b919c7a11462ef51). I was able to access the home page.
- Tested this on render's docker environment which drops the `CAP_AUDIT_WRITE` capability 