### PR TITLE
Properly configure LDAP group settings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -254,8 +254,11 @@ zulipConfiguration() {
         # Zulip settings.py / zproject specific overrides here
         if [ "$setting_key" = "AUTH_LDAP_CONNECTION_OPTIONS" ] || \
            [ "$setting_key" = "AUTH_LDAP_USER_SEARCH" ] || \
+           [ "$setting_key" = "AUTH_LDAP_GROUP_SEARCH" ] || \
            [ "$setting_key" = "AUTH_LDAP_REVERSE_EMAIL_SEARCH" ] || \
            [ "$setting_key" = "AUTH_LDAP_USER_ATTR_MAP" ] || \
+           [ "$setting_key" = "AUTH_LDAP_USER_FLAGS_BY_GROUP" ] || \
+           [ "$setting_key" = "AUTH_LDAP_GROUP_TYPE" ] || \
            { [ "$setting_key" = "LDAP_APPEND_DOMAIN" ] && [ "$setting_var" = "None" ]; } || \
            [ "$setting_key" = "SECURE_PROXY_SSL_HEADER" ] || \
            [[ "$setting_key" = "CSRF_"* ]] || \


### PR DESCRIPTION
Currently LDAP group settings are being treat as string, they should be treated as array so we could configure it correctly while executing on `docker` or `kubernetes`.