### PR TITLE
Add override for queue_workers_multiprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ which you need to encode in the YAML file.  For example,
   comma-separated list of the backend names
   (E.g. `"EmailAuthBackend,GitHubAuthBackend"`).
 
+**Reducing RAM usage**. By default, the Zulip server automatically detect
+whether the system has enough memory to run Zulip queue processors in the
+higher-throughput but more multiprocess mode (or to save 1.5GiB of RAM with
+the multithreaded mode). This algorithm might see the host's memory, not the
+docker container's memory. Set to `QUEUE_WORKERS_MULTIPROCESS` to `true` or
+`false` to override the automatic calculation.
+
 **SSL Certificates**.  By default, the image will generate a self-signed cert.
 You can set `SSL_CERTIFICATE_GENERATION: "certbot"` within `docker-compose.yml`
 to enable automatically-renewed Let's Encrypt certificates.  By using certbot

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -131,6 +131,20 @@ nginxConfiguration() {
     sed -i "s/proxy_buffering .*/proxy_buffering $NGINX_PROXY_BUFFERING;/g" /etc/nginx/zulip-include/proxy_longpolling
     echo "Nginx configuration succeeded."
 }
+additionalPuppetConfiguration() {
+    echo "Executing additional puppet configuration ..."
+    if [ "$QUEUE_WORKERS_MULTIPROCESS" == "True" ] || [ "$QUEUE_WORKERS_MULTIPROCESS" == "true" ]; then
+        echo "Setting queue workers to run in multiprocess mode ..."
+        crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess true
+    elif [ "$QUEUE_WORKERS_MULTIPROCESS" == "False" ] || [ "$QUEUE_WORKERS_MULTIPROCESS" == "false" ]; then
+        echo "Setting queue workers to run in multithreaded mode ..."
+        crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess false
+    else
+        echo "No additional puppet configuration executed."
+        return 0
+    fi
+    /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
+}
 configureCerts() {
     case "$SSL_CERTIFICATE_GENERATION" in
         self-signed)
@@ -294,6 +308,7 @@ initialConfiguration() {
     prepareDirectories
     nginxConfiguration
     configureCerts
+    additionalPuppetConfiguration
     if [ "$MANUAL_CONFIGURATION" = "False" ] || [ "$MANUAL_CONFIGURATION" = "false" ]; then
         # Start with the settings template file.
         cp -a /home/zulip/deployments/current/zproject/prod_settings_template.py "$SETTINGS_PY"


### PR DESCRIPTION
Adds a value for `queue_workers_multiprocess` in zulip.conf depending on the value of the `QUEUE_WORKERS_MULTIPROCESS` environment variable.

[This](https://github.com/zulip/zulip/pull/18224) is the corresponding PR in the Zulip repo, which adds `queue_workers_multiprocess` as a setting to zulip.conf. 

Zulip auto-detects how much system memory is available when deciding whether to run queue workers in a multiprocess or multithreaded fashion (Conversation on Zulip). For docker containers, the available memory of the host is detected, and this is not representative of the container's available memory.

**Testing**
This was tested on Render. Memory usage dropped as expected after the deploy:
<img width="437" alt="Screen Shot 2021-04-20 at 12 39 56 PM" src="https://user-images.githubusercontent.com/2397765/115456435-02fbdb00-a1d8-11eb-93de-646c0ccfcf67.png">

On the server with the deployment:
```
> cat /etc/zulip/zulip.conf 
[machine]
puppet_classes = zulip::dockervoyager
deploy_type = production


[rabbitmq]
nodename = zulip@localhost


[application_server]
http_only = true
queue_workers_multiprocess = false
```