### PR TITLE
Removing hostname from DockerCompose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     restart: always
   rabbitmq:
     image: 'rabbitmq:3.7.7'
-    hostname: zulip-rabbit
     restart: always
     environment:
         RABBITMQ_DEFAULT_USER: 'zulip'


### PR DESCRIPTION
As discussed in this issue the `hostname` is not necessary and just confusing: https://github.com/zulip/docker-zulip/issues/195