### PR TITLE
Use docker managed volumes in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,33 +55,14 @@ written to the image's filesystem is lost).  To handle persistent
 state that needs to persist after the Docker equivalent of a reboot or
 upgrades (like uploaded files or the Zulip database), container
 systems let you configure certain directories inside the container
-from the host system's filesystem.
+from the host.
 
-For example, this project's `docker-compose.yml` configuration file
-specifies a set of volumes where
-[persistent Zulip data][persistent-data] should be stored under
-`/opt/docker/zulip/` in the container host's file system:
+This project's `docker-compose.yml` configuration file uses [Docker managed
+volumes][volumes] to store [persistent Zulip data][persistent-data]. If you use
+the Docker Compose deployment, you should make sure that Zulip's volumes are
+backed up, to ensure that Zulip's data is backed up.
 
-* `/opt/docker/zulip/postgresql/data/` has the postgres container's
-  persistent storage (i.e. the database).
-* `/opt/docker/zulip/zulip/` has the application server container's
-  persistent storage, including the secrets file, uploaded files,
-  etc.
-
-This approach of mounting `/opt/docker` into the container is the
-right model if you're hosting your containers from a single host
-server, which is how `docker-compose` is intended to be used.  If
-you're using Kubernetes, Docker Swarm, or another cloud container
-service, then these persistent storage volumes are typically
-configured to be network block storage volumes (e.g. an Amazon EBS
-volume) so that they can be mounted from any server within the
-cluster.
-
-What this means is that if you're using `docker-zulip` in production
-with `docker-compose`, you'll want to configure your backup system to
-do backups on the `/opt/docker/zulip` directory, in order to ensure
-you don't lose data.
-
+[volumes]: https://docs.docker.com/storage/volumes/
 [persistent-data]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#backups
 
 ## Prerequisites

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # the first time on a host.  Instructions are available in README.md.
       POSTGRES_PASSWORD: "REPLACE_WITH_SECURE_POSTGRES_PASSWORD"
     volumes:
-      - "/opt/docker/zulip/postgresql/data:/var/lib/postgresql/data:rw"
+      - "postgresql-10:/var/lib/postgresql/data:rw"
   memcached:
     image: "memcached:alpine"
     restart: unless-stopped
@@ -34,7 +34,7 @@ services:
       RABBITMQ_DEFAULT_USER: "zulip"
       RABBITMQ_DEFAULT_PASS: "REPLACE_WITH_SECURE_RABBITMQ_PASSWORD"
     volumes:
-      - "/opt/docker/zulip/rabbitmq:/var/lib/rabbitmq:rw"
+      - "rabbitmq:/var/lib/rabbitmq:rw"
   redis:
     image: "redis:alpine"
     restart: unless-stopped
@@ -47,7 +47,7 @@ services:
     environment:
       REDIS_PASSWORD: "REPLACE_WITH_SECURE_REDIS_PASSWORD"
     volumes:
-      - "/opt/docker/zulip/redis:/data:rw"
+      - "redis:/data:rw"
   zulip:
     image: "zulip/docker-zulip:5.7-0"
     restart: unless-stopped
@@ -90,8 +90,13 @@ services:
       # Uncomment this when configuring the mobile push notifications service
       # SETTING_PUSH_NOTIFICATION_BOUNCER_URL: 'https://push.zulipchat.com'
     volumes:
-      - "/opt/docker/zulip/zulip:/data:rw"
+      - "zulip:/data:rw"
     ulimits:
       nofile:
         soft: 1000000
         hard: 1048576
+volumes:
+  zulip:
+  postgresql-10:
+  rabbitmq:
+  redis:


### PR DESCRIPTION
This is so that the compose file works across different platforms with no issues (I had an issue regarding permission to /opt directory).