### PR TITLE
Clarify path for manual configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Zulip server's settings.
 An alternative approach is to set `MANUAL_CONFIGURATION: "True"` and
 `LINK_SETTINGS_TO_DATA: "True"` in `docker-compose.yml`.  If you do that, you
 can provide a `settings.py` file and a `zulip-secrets.conf` file in
-`/opt/docker/zulip/zulip/`, and the container will use those.
+`/opt/docker/zulip/zulip/settings/etc-zulip/`, and the container will use those.
 
 ### Starting the server
 


### PR DESCRIPTION
The configuration files need to be placed in
`/opt/docker/zulip/zulip/settings/etc-zulip` so that Zulip will pick
them up properly. This commit clarifies that in the README.md file.