### PR TITLE
Update versions for Zulip Server 4.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /home/zulip
 # You can specify these in docker-compose.yml or with
 #   docker build --build-args "ZULIP_GIT_REF=git_branch_name" .
 ARG ZULIP_GIT_URL=https://github.com/zulip/zulip.git
-ARG ZULIP_GIT_REF=4.4
+ARG ZULIP_GIT_REF=4.5
 
 RUN git clone "$ZULIP_GIT_URL" && \
     cd zulip && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,13 +47,13 @@ services:
     volumes:
       - "/opt/docker/zulip/redis:/data:rw"
   zulip:
-    image: "zulip/docker-zulip:4.4-0"
+    image: "zulip/docker-zulip:4.5-0"
     build:
       context: .
       args:
         # Change these if you want to build zulip from a different repo/branch
         ZULIP_GIT_URL: https://github.com/zulip/zulip.git
-        ZULIP_GIT_REF: "4.4"
+        ZULIP_GIT_REF: "4.5"
         # Set this up if you plan to use your own CA certificate bundle for building
         # CUSTOM_CA_CERTIFICATES:
     ports:


### PR DESCRIPTION
Just update the version numbers to 4.5 for the new Zulip release.