### PR TITLE
Add noreply setting to default docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,9 @@ services:
       SETTING_ZULIP_ADMINISTRATOR: "admin@example.com"
       SETTING_EMAIL_HOST: "" # e.g. smtp.example.com
       SETTING_EMAIL_HOST_USER: "noreply@example.com"
+      # Force noreply@example.com to send emails
+      # See reasons to set it to True [here](https://zulip.readthedocs.io/en/latest/production/email.html#troubleshooting)
+      SETTING_ADD_TOKENS_TO_NOREPLY_ADDRESS: 'False'
       SETTING_EMAIL_PORT: "587"
       # It seems that the email server needs to use ssl or tls and can't be used without it
       SETTING_EMAIL_USE_SSL: "False"


### PR DESCRIPTION
I had to set this today because out of the box Zulip sends invites as noreply-<guid>@smtp.example.com instead of just noreply@smtp.example.com, which was causing email bounces as I didn't have a sending identity for that particular email address. The default is true for security reasons as listed in [this hack](https://medium.com/intigriti/how-i-hacked-hundreds-of-companies-through-their-helpdesk-b7680ddc2d4c), but I'd argue setting this setting to default to False will be the most pain-free way for most self-hosted users that are only running Zulip and not running it alongside an 'email to public support ticket tracker' feature. 

Having said that, even if it is preferred to leave this at True, it will still help smooth the way for self-hosted users to find and change this setting up front rather than needing to track this down and manually create the setting.