### PR TITLE
Write AUTH_LDAP_GLOBAL_OPTIONS as array

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -267,6 +267,7 @@ zulipConfiguration() {
         fi
         # Zulip settings.py / zproject specific overrides here
         if [ "$setting_key" = "AUTH_LDAP_CONNECTION_OPTIONS" ] || \
+           [ "$setting_key" = "AUTH_LDAP_GLOBAL_OPTIONS" ] || \
            [ "$setting_key" = "AUTH_LDAP_USER_SEARCH" ] || \
            [ "$setting_key" = "AUTH_LDAP_GROUP_SEARCH" ] || \
            [ "$setting_key" = "AUTH_LDAP_REVERSE_EMAIL_SEARCH" ] || \


### PR DESCRIPTION
Instead of string.

This is required for connecting to a LDAPS server without validating cert
```
SETTING_AUTH_LDAP_GLOBAL_OPTIONS: "{ ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_NEVER }"
```

Using `SETTING_AUTH_LDAP_CONNECTION_OPTIONS` doesn't work.