### PR TITLE
Add social auth oidc to entrypoint.sh script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -274,6 +274,7 @@ zulipConfiguration() {
            [ "$setting_key" = "AUTH_LDAP_USER_ATTR_MAP" ] || \
            [ "$setting_key" = "AUTH_LDAP_USER_FLAGS_BY_GROUP" ] || \
            [ "$setting_key" = "AUTH_LDAP_GROUP_TYPE" ] || \
+           [ "$setting_key" = "SOCIAL_AUTH_OIDC_ENABLED_IDPS" ] || \
            { [ "$setting_key" = "LDAP_APPEND_DOMAIN" ] && [ "$setting_var" = "None" ]; } || \
            [ "$setting_key" = "SECURE_PROXY_SSL_HEADER" ] || \
            [[ "$setting_key" = "CSRF_"* ]] || \


### PR DESCRIPTION
add social auth oidc to entrypoint.sh script so you can set it with env variables.

I originally pushed this as part of #325 but I noticed that that one is hard to merge, whereas this is a super simple bugfix.