### PR TITLE
Add setting for loadbalancer IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,10 @@ putting it in `/opt/docker/zulip/zulip/certs/` (by default, the
 `zulip` container startup script will generate a self-signed certificate and
 install it in that directory).
 
-**Loadbalancer**. To tell Zulip it's behind a loadbalancer, you can set
+**Load balancer**. To tell Zulip it's behind a loadbalancer, you can set
 `LOADBALANCER_IPS` to a comma-separated list of IPs. This will tell Zulip
-to pass the real IP of the client instead of the IP of the loadbalancer itself.
+to pass the real IP of the client instead of the IP of the loadbalancer itself
+by [setting the IPs][configuring-zulip-to-trust-proxies] under `[loadbalancer]` in `zulip.conf`.
 
 ### Manual configuration
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ putting it in `/opt/docker/zulip/zulip/certs/` (by default, the
 `zulip` container startup script will generate a self-signed certificate and
 install it in that directory).
 
+**Loadbalancer**. To tell Zulip it's behind a loadbalancer, you can set
+`LOADBALANCER_IPS` to a comma-separated list of IPs. This will tell Zulip
+to pass the real IP of the client instead of the IP of the loadbalancer itself.
+
 ### Manual configuration
 
 The way the environment variables configuration process described in

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ install it in that directory).
 **Load balancer**. To tell Zulip it's behind a loadbalancer, you can set
 `LOADBALANCER_IPS` to a comma-separated list of IPs. This will tell Zulip
 to pass the real IP of the client instead of the IP of the loadbalancer itself
-by [setting the IPs][configuring-zulip-to-trust-proxies] under `[loadbalancer]` in `zulip.conf`.
+by [setting the IPs][loadbalancer-ips] under `[loadbalancer]` in `zulip.conf`.
+
+[loadbalancer-ips]: https://zulip.readthedocs.io/en/latest/production/deployment.html#configuring-zulip-to-trust-proxies
 
 ### Manual configuration
 

--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ putting it in `/opt/docker/zulip/zulip/certs/` (by default, the
 `zulip` container startup script will generate a self-signed certificate and
 install it in that directory).
 
-**Load balancer**. To tell Zulip it's behind a loadbalancer, you can set
+**Load balancer**. To tell Zulip it's behind a load balancer, you can set
 `LOADBALANCER_IPS` to a comma-separated list of IPs. This will tell Zulip
-to pass the real IP of the client instead of the IP of the loadbalancer itself
+to pass the real IP of the client instead of the IP of the load balancer itself
 by [setting the IPs][loadbalancer-ips] under `[loadbalancer]` in `zulip.conf`.
 
 [loadbalancer-ips]: https://zulip.readthedocs.io/en/latest/production/deployment.html#configuring-zulip-to-trust-proxies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     volumes:
       - "/opt/docker/zulip/redis:/data:rw"
   zulip:
-    image: "zulip/docker-zulip:5.2-1"
+    image: "zulip/docker-zulip:5.2-0"
     build:
       context: .
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     volumes:
       - "/opt/docker/zulip/redis:/data:rw"
   zulip:
-    image: "zulip/docker-zulip:5.2-0"
+    image: "zulip/docker-zulip:5.2-1"
     build:
       context: .
       args:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,7 +148,7 @@ additionalPuppetConfiguration() {
         echo "Setting IPs for load balancer"
         crudini --set /etc/zulip/zulip.conf loadbalancer ips "${LOADBALANCER_IPS}"
     else
-	echo "No additional puppet configuration executed for loadbalanacer IPs."
+	echo "No additional puppet configuration executed for load balancer IPs."
     fi
     
     /home/zulip/deployments/current/scripts/zulip-puppet-apply -f

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,6 +133,7 @@ nginxConfiguration() {
 }
 additionalPuppetConfiguration() {
     echo "Executing additional puppet configuration ..."
+    
     if [ "$QUEUE_WORKERS_MULTIPROCESS" == "True" ] || [ "$QUEUE_WORKERS_MULTIPROCESS" == "true" ]; then
         echo "Setting queue workers to run in multiprocess mode ..."
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess true
@@ -140,9 +141,15 @@ additionalPuppetConfiguration() {
         echo "Setting queue workers to run in multithreaded mode ..."
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess false
     else
-        echo "No additional puppet configuration executed."
+        echo "No additional puppet configuration executed for queue workers."
         return 0
     fi
+    
+    if [ -n "$LOADBALANCER_IPS" ]; then
+        echo "Setting IPs for load balancer"
+        crudini --set /etc/zulip/zulip.conf loadbalancer ips "${LOADBALANCER_IPS}"
+    fi
+    
     /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
 }
 configureCerts() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,12 +142,13 @@ additionalPuppetConfiguration() {
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess false
     else
         echo "No additional puppet configuration executed for queue workers."
-        return 0
     fi
     
     if [ -n "$LOADBALANCER_IPS" ]; then
         echo "Setting IPs for load balancer"
         crudini --set /etc/zulip/zulip.conf loadbalancer ips "${LOADBALANCER_IPS}"
+    else
+	echo "No additional puppet configuration executed for loadbalanacer IPs."
     fi
     
     /home/zulip/deployments/current/scripts/zulip-puppet-apply -f

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,13 +133,17 @@ nginxConfiguration() {
 }
 additionalPuppetConfiguration() {
     echo "Executing additional puppet configuration ..."
+
+    local changedPuppetConf=false
     
     if [ "$QUEUE_WORKERS_MULTIPROCESS" == "True" ] || [ "$QUEUE_WORKERS_MULTIPROCESS" == "true" ]; then
         echo "Setting queue workers to run in multiprocess mode ..."
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess true
+        changedPuppetConf=true
     elif [ "$QUEUE_WORKERS_MULTIPROCESS" == "False" ] || [ "$QUEUE_WORKERS_MULTIPROCESS" == "false" ]; then
         echo "Setting queue workers to run in multithreaded mode ..."
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess false
+        changedPuppetConf=true
     else
         echo "No additional puppet configuration executed for queue workers."
     fi
@@ -147,11 +151,14 @@ additionalPuppetConfiguration() {
     if [ -n "$LOADBALANCER_IPS" ]; then
         echo "Setting IPs for load balancer"
         crudini --set /etc/zulip/zulip.conf loadbalancer ips "${LOADBALANCER_IPS}"
+        changedPuppetConf=true
     else
 	echo "No additional puppet configuration executed for load balancer IPs."
     fi
-    
-    /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
+
+    if [ "$changedPuppetConf" = true ]; then
+        /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
+    fi
 }
 configureCerts() {
     case "$SSL_CERTIFICATE_GENERATION" in


### PR DESCRIPTION
This PR adds the possibility to set loadbalancer IPs in `zulip.conf` using Docker container environment parameters.