### PR TITLE
Support incoming email integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ by [setting the IPs][loadbalancer-ips] under `[loadbalancer]` in `zulip.conf`.
 
 [loadbalancer-ips]: https://zulip.readthedocs.io/en/latest/production/deployment.html#configuring-zulip-to-trust-proxies
 
+**Additional puppet classes**. If you need to do additional puppet classes, you can set `ADDITIONAL_PUPPET_CLASSES` to a comma-separated list of puppet classes. This will tell Zulip to run the puppet classes under `[additional_puppet_classes]` in `zulip.conf`.
+For example: `ADDITIONAL_PUPPET_CLASSES="zulip::postfix_localmail"`.
+
+**Mail name**. If you need to set the mail name to used in [Local delivery setup for incoming email integration](https://zulip.readthedocs.io/en/latest/production/email-gateway.html#local-delivery-setup), you can set `MAILNAME` to the mail name. This will tell Zulip to add the mail name configuration under `[postfix]` in `zulip.conf`.
+
+
 ### Manual configuration
 
 The way the environment variables configuration process described in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -156,6 +156,34 @@ additionalPuppetConfiguration() {
         echo "No additional puppet configuration executed for load balancer IPs."
     fi
 
+    if [ -n "$ADDITIONAL_PUPPET_CLASSES" ]; then
+        echo "Add additional puppet classes"
+        current_classes=$(crudini --get /etc/zulip/zulip.conf machine puppet_classes)
+        if [ -n "$current_classes" ]; then
+            echo "Add additional puppet classes to existing"
+            crudini --set /etc/zulip/zulip.conf machine puppet_classes "${current_classes}, ${ADDITIONAL_PUPPET_CLASSES}"
+        else
+            echo "No existing puppet classes, just setting"
+            crudini --set /etc/zulip/zulip.conf machine puppet_classes "${ADDITIONAL_PUPPET_CLASSES}"
+        fi
+        changedPuppetConf=true
+        requireUpdateApt=true
+    else
+        echo "No additional puppet classes."
+    fi
+
+    if [ -n "$MAILNAME" ]; then
+        echo "Setup mail name for postfix"
+        crudini --set /etc/zulip/zulip.conf postfix mailname "${MAILNAME}"
+        changedPuppetConf=true
+    else
+        echo "No config for mail name for postfix"
+    fi
+
+    if [ "$requireUpdateApt" = true ]; then
+      apt update
+    fi
+
     if [ "$changedPuppetConf" = true ]; then
         /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -135,6 +135,7 @@ additionalPuppetConfiguration() {
     echo "Executing additional puppet configuration ..."
 
     local changedPuppetConf=false
+    local requireUpdateApt=false
 
     if [ "$QUEUE_WORKERS_MULTIPROCESS" == "True" ] || [ "$QUEUE_WORKERS_MULTIPROCESS" == "true" ]; then
         echo "Setting queue workers to run in multiprocess mode ..."
@@ -183,7 +184,6 @@ additionalPuppetConfiguration() {
     if [ "$requireUpdateApt" = true ]; then
       apt update
     fi
-
     if [ "$changedPuppetConf" = true ]; then
         /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
     fi


### PR DESCRIPTION
Add several configurations to support incoming email integration.

Probably will solve https://github.com/zulip/docker-zulip/issues/192.

Related: https://github.com/zulip/docker-zulip/issues/237 https://github.com/zulip/docker-zulip/pull/220

Related PR in zulip repo: https://github.com/zulip/zulip/pull/24098 https://github.com/zulip/zulip/pull/24097