### PR TITLE
Wrong tag for postgresql image

### DIFF
--- a/kubernetes/manual/zulip-rc.yml
+++ b/kubernetes/manual/zulip-rc.yml
@@ -70,7 +70,7 @@ spec:
             - name: rabbitmq-persistent-storage
               mountPath: /var/lib/rabbitmq
         - name: postgresql
-          image: zulip/zulip-postgresql
+          image: zulip/zulip-postgresql:14
           resources:
             limits:
               cpu: 80m


### PR DESCRIPTION
Hi,

The image specified for postgresql doesn't work, we have to specify tag "14" because the "latest" tag on the image "zulip-postgresql" is PostgreSQL 10 and not 14.

Cause the following error : "django.db.utils.NotSupportedError: PostgreSQL 11 or later is required (found 10.17)."

However, the best way to solve this problem is to update the "latest" tag.