### PR TITLE
upgrade-postgresql: Fix ${} vs $() typo.

### DIFF
--- a/upgrade-postgresql
+++ b/upgrade-postgresql
@@ -11,7 +11,7 @@ fi
 
 # Require docker-compose 2.1.1 or higher, for `docker-compose up --wait`
 docker_compose_version=$(docker-compose --version --short)
-if [ "$(docker_compose_version)" = "$(echo -e "2.1.0\n${docker_compose_version}" | sort -V | head -n1)" ]; then
+if [ "${docker_compose_version}" = "$(echo -e "2.1.0\n${docker_compose_version}" | sort -V | head -n1)" ]; then
 	echo "Your docker-compose is too old (${docker_compose_version}); upgrade to at least 2.1.1."
 	exit 1
 fi


### PR DESCRIPTION
This caused a "Command not found" and no effective check on the version of docker-compose.