### PR TITLE
entrypoint: Consider SOCIAL_AUTH_SAML_ENABLED_IDPS as an array in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -290,6 +290,7 @@ zulipConfiguration() {
            [ "$setting_key" = "AUTH_LDAP_USER_FLAGS_BY_GROUP" ] || \
            [ "$setting_key" = "AUTH_LDAP_GROUP_TYPE" ] || \
            [ "$setting_key" = "SOCIAL_AUTH_OIDC_ENABLED_IDPS" ] || \
+           [ "$setting_key" = "SOCIAL_AUTH_SAML_ENABLED_IDPS" ] || \
            { [ "$setting_key" = "LDAP_APPEND_DOMAIN" ] && [ "$setting_var" = "None" ]; } || \
            [ "$setting_key" = "SECURE_PROXY_SSL_HEADER" ] || \
            [[ "$setting_key" = "CSRF_"* ]] || \


### PR DESCRIPTION
When adding proper `SOCIAL_AUTH_SAML_ENABLED_IDPS: Dict[str, Any]` in values.yaml, zulip is failing to start by stating that `SOCIAL_AUTH_SAML_ENABLED_IDPS` got invalid string, since the condition is missing. Kindly evaluate the PR. 