### PR TITLE
🐛 fix: better number type setting check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,19 +86,26 @@ setConfigurationValue() {
     local TYPE="$4"
     if [ -z "$TYPE" ]; then
         case "$2" in
-            [Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee]|[Nn]one)
-            TYPE="bool"
-            ;;
-            [1-9][0-9]*)
-            TYPE="integer"
-            ;;
-            [\[\(]*[\]\)])
-            TYPE="array"
+            ''|*[!0-9]*)
+            TYPE="not-integer"
             ;;
             *)
-            TYPE="string"
+            TYPE="integer"
             ;;
         esac
+        if [ "$TYPE" != "integer" ]; then
+            case "$2" in
+                [Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee]|[Nn]one)
+                TYPE="bool"
+                ;;
+                [\[\(]*[\]\)])
+                TYPE="array"
+                ;;
+                *)
+                TYPE="string"
+                ;;
+            esac
+        fi
     fi
     case "$TYPE" in
         emptyreturn)


### PR DESCRIPTION
before this, if you have string value but starting with number it will act as a number, So I added a better checking method for that

to test that you can run:

```bash
case "6a6" in ''|*[!0-9]*) echo false; ;; esac
case "66" in ''|*[!0-9]*) echo false; ;; esac
```

second one will be false and we will use it as a number