### PR TITLE
Add option to disable outgoing proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ proxies][other-proxy].
 [haproxy-proxy]: https://zulip.readthedocs.io/en/latest/production/deployment.html#haproxy-configuration
 [other-proxy]: https://zulip.readthedocs.io/en/latest/production/deployment.html#other-proxies
 
+**Outgoing proxy**. By default, Zulip proxies outgoing requests with
+Smokescreen to protect against SSRF. However, in development scenarios,
+this might interfere with your ability to connect to bots or other
+integrations running on the local machine. To disable this protection,
+you can set `DISABLE_OUTGOING_PROXY: "True"` within `docker-compose.yml`.
+For more information, see [Customizing the outgoing HTTP
+proxy][outgoing-proxy].
+
+[outgoing-proxy]: https://zulip.readthedocs.io/en/latest/production/deployment.html#customizing-the-outgoing-http-proxy
+
 ### Manual configuration
 
 The way the environment variables configuration process described in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       SETTING_EMAIL_USE_SSL: "False"
       SETTING_EMAIL_USE_TLS: "True"
       ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
+      # Disabling the outgoing proxy can be useful for development purposes,
+      # but it should be left enabled in production to protect against SSRF
+      DISABLE_OUTGOING_PROXY: "False"
       # Uncomment this when configuring the mobile push notifications service
       # SETTING_PUSH_NOTIFICATION_BOUNCER_URL: 'https://push.zulipchat.com'
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,6 +148,14 @@ puppetConfiguration() {
 
     /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
 }
+outgoingProxyConfiguration() {
+    echo "Executing outgoing proxy configuration ..."
+    if [ "$DISABLE_OUTGOING_PROXY" == "True" ] || [ "$DISABLE_OUTGOING_PROXY" == "true" ]; then
+        echo "Disabling outgoing proxy."
+        crudini --set /etc/zulip/zulip.conf http_proxy host ""
+        /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
+    fi
+}
 configureCerts() {
     case "$SSL_CERTIFICATE_GENERATION" in
         self-signed)
@@ -320,6 +328,7 @@ initialConfiguration() {
     puppetConfiguration
     nginxConfiguration
     configureCerts
+    outgoingProxyConfiguration
     if [ "$MANUAL_CONFIGURATION" = "False" ] || [ "$MANUAL_CONFIGURATION" = "false" ]; then
         # Start with the settings template file.
         cp -a /home/zulip/deployments/current/zproject/prod_settings_template.py "$SETTINGS_PY"


### PR DESCRIPTION
This adds an option to docker-compose.yml to disable Smokescreen, the outgoing HTTP proxy, for development use cases where you want to test bots and integrations that are running on the local machine alongside Zulip. The SSRF protection provided by Smokescreen normally prevents such connections to the local machine from working, making it difficult to do such testing. This is something we found useful at our organization for testing our integrations. Let me know if you think this might be useful for others.

Thanks, Shawn