### PR TITLE
fix broken manage.py backup command by downgrade postgresql client version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN \
     cp -rf /root/custom_zulip/* /root/zulip && \
     rm -rf /root/custom_zulip && \
     export PUPPET_CLASSES="zulip::profile::docker" && \
-    /root/zulip/scripts/setup/install --hostname="$(hostname)" --email="docker-zulip" --no-init-db && \
+    /root/zulip/scripts/setup/install --hostname="$(hostname)" --email="docker-zulip" --postgresql-version=14 --no-init-db && \
     rm -f /etc/zulip/zulip-secrets.conf /etc/zulip/settings.py && \
     apt-get -qq autoremove --purge -y && \
     apt-get -qq clean && \


### PR DESCRIPTION
zulip install postgresql 16 by default.downgrade postgresql version to 14 during zulip install, since postgresql dependency in docker compose is 14. 

zulip 9.1 install postgresql 16: https://github.com/zulip/zulip/blob/9.1/docs/production/deployment.md?plain=1#L70-L72
postgresql dependency in docker compose: https://github.com/zulip/docker-zulip/blob/main/docker-compose.yml#L14
zulip install postgresql 16 by default

manage.py backup will use postgresql serversion version to determine pg_dump path https://github.com/zulip/zulip/blob/9.1/zerver/management/commands/backup.py, since client version and server version is not match, backup command will fail. 

fix https://github.com/zulip/docker-zulip/issues/423 and https://github.com/zulip/docker-zulip/issues/447