### PR TITLE
add the posibility to add external secrets as env variables

### DIFF
--- a/kubernetes/chart/zulip/templates/statefulset.yaml
+++ b/kubernetes/chart/zulip/templates/statefulset.yaml
@@ -52,6 +52,11 @@ spec:
               mountPath: /data/post-setup.d
           env:
             {{ include "zulip.env" . | nindent 12 }}
+          {{- if .Values.envSecrets }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.zulip.envSecrets }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.livenessProbe.enabled }}

--- a/kubernetes/chart/zulip/values.yaml
+++ b/kubernetes/chart/zulip/values.yaml
@@ -139,6 +139,22 @@ zulip:
     SETTING_EMAIL_USE_SSL: "False"
     SETTING_EMAIL_USE_TLS: "True"
     ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
+  # -- Mount a environment variables from secrets. Name the secret name.
+  # If you have a secret with env. variables created named zulip-secrets
+  # you will add:
+  # `envSecrets: zulip-secrets`
+  # The secrets file you manually create in the namespace, can look something
+  # like this (secrets need to be base64 encoded):
+  # ---
+  # apiVersion: v1
+  # kind: Secret
+  # metadata:
+  #   name: zulip-secrets
+  # type: Opaque
+  # data:
+  #   SECRETS_email_password: MTIzNDU2Nzg5
+  #   MY_OTHER_SECRET: Zm9vaXNiYXI=
+  envSecrets:
   # -- If `persistence.existingClaim` is not set, a PVC is generated with these
   # specifications.
   persistence:


### PR DESCRIPTION
This small change adds the posibility to add environments variables from an external secret. Good when you want to keep secrets out of your overrides, or are using an external resource to create the environment variables.