### PR TITLE
Improve several aspects of the Docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ which you need to encode in the YAML file. For example,
   comma-separated list of the backend names
   (E.g. `"EmailAuthBackend,GitHubAuthBackend"`).
 
+- LDAP authentication currently requires
+  [`MANUAL_CONFIGURATION`](#manual-configuration) in order to encode
+  the `LDAPSearch` logic, see below.
+
 **Reducing RAM usage**. By default, the Zulip server automatically detect
 whether the system has enough memory to run Zulip queue processors in the
 higher-throughput but more multiprocess mode (or to save 1.5GiB of RAM with

--- a/README.md
+++ b/README.md
@@ -1,69 +1,27 @@
-# Welcome to docker-zulip!
+# Zulip Docker image overview
 
 [![](https://images.microbadger.com/badges/image/zulip/docker-zulip.svg)](https://microbadger.com/images/zulip/docker-zulip "Get your own image badge on microbadger.com") [![**docker-zulip** stream](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org/#narrow/stream/backend/topic/docker)
 
-This is a container image for running [Zulip](https://zulip.com)
-([GitHub](https://github.com/zulip/zulip)) in
-[production][prod-overview]. Image available from:
+`docker-zulip` is the official Docker container image for running a
+[Zulip server](https://zulip.com) in
+[production][prod-overview]. Built images are available from: [Docker
+Hub](https://hub.docker.com/r/zulip/docker-zulip):
 
-- [**Docker Hub**](https://hub.docker.com/r/zulip/docker-zulip) (`docker pull zulip/docker-zulip:9.2-0`)
+```console
+$ docker pull zulip/docker-zulip:9.2-0`
+```
 
 Current Zulip version: `9.2`
 Current Docker image version: `9.2-0`
 
-Project status: **Alpha**. While this project works and is
-used by many sites in production, configuring is substantially more
-error-prone than the [normal Zulip installer][normal-install] (which
-Just Works). We recommend this project if you want to host Zulip
-using Docker, but both setting up and maintaining a Zulip server is
-simpler and less error-prone with the normal installer than with Docker.
+We recommend using the Docker image if your organization has a
+preference for deploying services using Docker. Deploying with Docker
+moderately increases the effort required to install, maintain, and
+upgrade a Zulip installation, compared with the [standard Zulip
+installer][normal-install].  ￼
 
 [normal-install]: https://zulip.readthedocs.io/en/latest/production/install.html
-
-## Overview
-
-This project defines a Docker image for a Zulip server, as well as
-sample configuration to run that Zulip web/application server with
-each of the major [services that Zulip uses][zulip-architecture] in
-its own container: `redis`, `postgres`, `rabbitmq`, `memcached`.
-
-We have configuration and documentation for
-[Docker Compose](#running-a-zulip-server-with-docker-compose) and
-[Kubernetes](#running-a-zulip-server-with-kubernetes); contributions are welcome for
-documenting other container runtimes and flows.
-
-If you aren't already a Docker expert, we recommend starting by
-reading our brief overview of how Docker and containers work in the
-next section.
-
 [zulip-architecture]: https://zulip.readthedocs.io/en/latest/overview/architecture-overview.html
-
-### The Docker data storage model
-
-Docker and other container systems are built around shareable
-container images. An image is a read-only template with instructions
-for creating a container. Often, an image is based on another image,
-with a bit of additional customization. For example, Zulip's
-`zulip-postgresql` image extends the standard `postgresql` image (by
-installing a couple `postgres` extensions). And the `zulip` image is
-built on top of a standard `ubuntu` image, adding all the code for a Zulip
-application/web server.
-
-Every time you boot a container based on a given image, it's like
-booting off a CD-ROM: you get the exact same image (and anything
-written to the image's filesystem is lost). To handle persistent
-state that needs to persist after the Docker equivalent of a reboot or
-upgrades (like uploaded files or the Zulip database), container
-systems let you configure certain directories inside the container
-from the host.
-
-This project's `docker-compose.yml` configuration file uses [Docker managed
-volumes][volumes] to store [persistent Zulip data][persistent-data]. If you use
-the Docker Compose deployment, you should make sure that Zulip's volumes are
-backed up, to ensure that Zulip's data is backed up.
-
-[volumes]: https://docs.docker.com/storage/volumes/
-[persistent-data]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#backups
 
 ## Prerequisites
 
@@ -86,10 +44,56 @@ To use `docker-zulip`, you need the following:
   descriptions via `ulimit` (which is important for it to handle
   thousands of connected clients).
 
+If you aren't already a Docker expert, we recommend starting by
+reading our brief overview of how Docker and containers work in the
+next section for important background that the rest of this
+documentation will assume.
+
+Otherwise, you can jump to our documentation for your preferred
+container runtime:
+
+- [Docker Compose](#running-a-zulip-server-with-docker-compose)
+- [Kubernetes](#running-a-zulip-server-with-kubernetes)
+
 [install-docker]: https://docs.docker.com/install/
 [install-docker-compose]: https://docs.docker.com/compose/install/
 [prod-overview]: https://zulip.readthedocs.io/en/latest/production/overview.html
 [prod-requirements]: https://zulip.readthedocs.io/en/latest/production/requirements.html
+
+## The Docker data storage model
+
+Docker and other container systems are built around shareable
+container images. An image is a read-only template with instructions
+for creating a container.
+
+Often, an image is based on another image, with a bit of additional
+customization. For example, Zulip's `zulip-postgresql` image extends
+the standard `postgresql` image (by installing a couple `postgres`
+extensions). Meanwhile, the `zulip` image is built on top of a
+standard `ubuntu` image, adding all the code for a Zulip
+application/web server.
+
+Every time you boot a container based on a given image, it's like
+booting off a CD-ROM: you get the exact same image (and anything
+written to the image's filesystem is lost). To handle persistent
+state that needs to persist after the Docker equivalent of a reboot or
+upgrades (like uploaded files or the Zulip database), container
+systems let you configure certain directories inside the container
+from the host.
+
+This project's `docker-compose.yml` configuration file uses [Docker
+managed volumes][volumes] to store [persistent Zulip
+data][persistent-data]. If you use the Docker Compose deployment, you
+should make sure that Zulip's volumes are backed up, to ensure that
+Zulip's data is backed up.
+
+This project defines a Docker image for a Zulip server, as well as
+sample configuration to run that Zulip server with each of the major
+[services that Zulip uses][zulip-architecture] in its own container:
+`redis`, `postgres`, `rabbitmq`, `memcached`.
+
+[volumes]: https://docs.docker.com/storage/volumes/
+[persistent-data]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#backups
 
 ## Running a Zulip server with docker-compose
 
@@ -102,9 +106,9 @@ cd docker-zulip
 # Edit `docker-compose.yml` to configure; see docs below
 ```
 
-If you're in hurry to try Zulip, you can skip to
-[start the Zulip server](#starting-the-server), but for production
-use, you'll need to do some configuration.
+If you're in hurry to try Zulip, you can skip to [start the Zulip
+server](#starting-the-server), but for production use, you'll need to
+generate secrets and do some configuration.
 
 ### Configuration
 
@@ -122,20 +126,20 @@ discussion in the main [Zulip installation docs][install-normal]):
 - `SETTING_ZULIP_ADMINISTRATOR`: The email address to receive error
   and support emails generated by the Zulip server and its users.
 
-**Mandatory settings for serious use**. Before you allow
-production traffic, you need to also set these:
+**Mandatory settings for produciton use**. Before you allow production
+traffic, you need to generate secrets. We recommend using long random
+strings of alphanumeric characters for your secrets; not every special
+character works.
 
-- `POSTGRES_PASSWORD` and `SECRETS_postgres_password` should both be a
-  password for the Zulip container to authenticate to the Postgres
-  container. Since you won't use this directly, you just want a long,
-  randomly generated string. While `SECRETS_postgres_password` is
+- `POSTGRES_PASSWORD` is the password for the PostgreSQL
+  instance. `SECRETS_postgres_password` configures the Zulip server to
+  know the PostgreSQL password. While `SECRETS_postgres_password` is
   synced to the Zulip container on every boot, `POSTGRES_PASSWORD` is
   only accessed by the postgres container on first boot, so if you
   later want to change your postgres password after booting the
-  container, you'll need to either do an
-  [ALTER ROLE][postgres-alter-role] query inside the `postgres`
-  container or rebuild the postgres database (only if you don't need
-  your data!).
+  container, you'll need to either do an [ALTER
+  ROLE][postgres-alter-role] query inside the `postgres` container or
+  rebuild the postgres database (only if you don't need your data!).
 - `RABBITMQ_DEFAULT_PASS` and `SECRETS_rabbitmq_password` are similar,
   just for the RabbitMQ container.
 - `MEMCACHED_PASSWORD` and `SECRETS_memcached_password` are similar,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     environment:
       POSTGRES_DB: "zulip"
       POSTGRES_USER: "zulip"
-      # Note that you need to do a manual `ALTER ROLE` query if you
-      # change this on a system after booting the postgres container
-      # the first time on a host.  Instructions are available in README.md.
+      ## Note that you need to do a manual `ALTER ROLE` query if you
+      ## change this on a system after booting the postgres container
+      ## the first time on a host.  Instructions are available in README.md.
       POSTGRES_PASSWORD: "REPLACE_WITH_SECURE_POSTGRES_PASSWORD"
     volumes:
       - "postgresql-14:/var/lib/postgresql/data:rw"
@@ -53,18 +53,18 @@ services:
     build:
       context: .
       args:
-        # Change these if you want to build zulip from a different repo/branch
+        ## Change these if you want to build zulip from a different repo/branch
         ZULIP_GIT_URL: https://github.com/zulip/zulip.git
         ZULIP_GIT_REF: "9.2"
-        # Set this up if you plan to use your own CA certificate bundle for building
+        ## Set this up if you plan to use your own CA certificate bundle for building
         # CUSTOM_CA_CERTIFICATES:
     ports:
       - "80:80"
       - "443:443"
     environment:
-      # See https://github.com/zulip/docker-zulip#configuration for
-      # details on this section and how to discover the many
-      # additional settings that are supported here.
+      ## See https://github.com/zulip/docker-zulip#configuration for
+      ## details on this section and how to discover the many
+      ## additional settings that are supported here.
       DB_HOST: "database"
       DB_HOST_PORT: "5432"
       DB_USER: "zulip"
@@ -73,8 +73,8 @@ services:
       SETTING_RABBITMQ_HOST: "rabbitmq"
       SETTING_REDIS_HOST: "redis"
       SECRETS_email_password: "123456789"
-      # These should match RABBITMQ_DEFAULT_PASS, POSTGRES_PASSWORD,
-      # MEMCACHED_PASSWORD, and REDIS_PASSWORD above.
+      ## These should match RABBITMQ_DEFAULT_PASS, POSTGRES_PASSWORD,
+      ## MEMCACHED_PASSWORD, and REDIS_PASSWORD above.
       SECRETS_rabbitmq_password: "REPLACE_WITH_SECURE_RABBITMQ_PASSWORD"
       SECRETS_postgres_password: "REPLACE_WITH_SECURE_POSTGRES_PASSWORD"
       SECRETS_memcached_password: "REPLACE_WITH_SECURE_MEMCACHED_PASSWORD"
@@ -85,17 +85,33 @@ services:
       SETTING_EMAIL_HOST: "" # e.g. smtp.example.com
       SETTING_EMAIL_HOST_USER: "noreply@example.com"
       SETTING_EMAIL_PORT: "587"
-      # It seems that the email server needs to use ssl or tls and can't be used without it
+      ## It seems that the email server needs to use ssl or tls and can't be used without it
       SETTING_EMAIL_USE_SSL: "False"
       SETTING_EMAIL_USE_TLS: "True"
       ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
-      # Uncomment this when configuring the mobile push notifications service
+      ## Uncomment this when configuring the mobile push notifications service
       # SETTING_ZULIP_SERVICE_PUSH_NOTIFICATIONS: "True"
       # SETTING_ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS: "True"
 
-      # If you're using a reverse proxy, you'll want to provide the
-      # comma-separated set of IP addresses to trust here.
+      ## If you're using a reverse proxy, you'll want to provide the
+      ## comma-separated set of IP addresses to trust here.
       # LOADBALANCER_IPS: "",
+
+      ## By default, files uploaded by users and profile pictures are
+      ## stored directly on the Zulip server. You can configure files
+      ## to be stored in Amazon S3 or a compatible data store
+      ## here. See docs at:
+      ##
+      ##   https://zulip.readthedocs.io/en/latest/production/upload-backends.html
+      ##
+      ## If you want to use the S3 backend, you must set
+      ## SETTINGS_LOCAL_UPLOADS_DIR to None as well as configuring the
+      ## other fields.
+      # SETTINGS_LOCAL_UPLOADS_DIR: "None"
+      # SETTINGS_S3_AUTH_UPLOADS_BUCKET: ""
+      # SETTINGS_S3_AVATAR_BUCKET: ""
+      # SETTINGS_S3_ENDPOINT_URL: "None"
+      # SETTINGS_S3_REGION: "None"
     volumes:
       - "zulip:/data:rw"
     ulimits:

--- a/kubernetes/chart/zulip/Chart.yaml
+++ b/kubernetes/chart/zulip/Chart.yaml
@@ -3,15 +3,17 @@ description: Zulip is an open source threaded team chat that helps teams stay pr
 name: zulip
 type: application
 icon: https://raw.githubusercontent.com/zulip/zulip/main/static/images/logo/zulip-icon-square.svg
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+## This is the chart version. This version number should be
+## incremented each time you make changes to the chart and its
+## templates, including the app version.  Versions are expected to
+## follow Semantic Versioning (https://semver.org/)
 version: 0.9.20
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+## This is the version number of the application being deployed. This
+## version number should be incremented each time you make changes to
+## the application. Versions are not expected to follow Semantic
+## Versioning. They should reflect the version the application is
+## using.  It is recommended to use it with quotes.
 appVersion: "9.2-0"
 dependencies:
   - name: memcached
@@ -33,7 +35,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - postgresql
-    # Note: values.yaml overwrites posgresql image to zulip/zulip-postgresql:14
+    ## Note: values.yaml overwrites posgresql image to zulip/zulip-postgresql:14
     version: 15.5.32
 
 sources:

--- a/kubernetes/chart/zulip/values.yaml
+++ b/kubernetes/chart/zulip/values.yaml
@@ -1,59 +1,61 @@
-# Default values for zulip.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-# If you make any changes to the documentation here, regenerate the README.md
-# with:
-#
-# ```
-# docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
-# ```
+## Default values for zulip.
+## This is a YAML-formatted file.
+##
+## Declare variables to be passed into your templates.
+## If you make any changes to the documentation here, regenerate the README.md
+## with:
+##
+## ```
+## docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
+## ```
 
 image:
-  # -- Defaults to hub.docker.com/zulip/docker-zulip, but can be overwritten with a full HTTPS address.
+  ## Defaults to https://hub.docker.com/zulip/docker-zulip, but can be
+  ## overwritten with a full HTTPS address.
   repository: zulip/docker-zulip
-  # -- Pull policy for Zulip docker image.
-  # Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ## Pull policy for Zulip docker image.
+  ## Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   pullPolicy: IfNotPresent
-  # -- Zulip image tag (immutable tags are recommended)
+  ## Zulip image tag (immutable tags are recommended)
   tag: "9.2-0"
 
-# -- Global Docker registry secret names as an array.
+## Global Docker registry secret names as an array.
 imagePullSecrets: []
 
-# -- Partially override common.names.fullname template (will maintain the release name).
+## Partially override common.names.fullname template (will maintain the release name).
 nameOverride: ""
 
-# -- Fully override common.names.fullname template.
+## Fully override common.names.fullname template.
 fullnameOverride: ""
 
 serviceAccount:
-  # -- Specifies whether a service account should be created.
+  ## Specifies whether a service account should be created.
   create: true
-  # -- Annotations to add to the service account.
+  ## Annotations to add to the service account.
   annotations: {}
-  # -- The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# -- Custom labels to add to the Zulip StatefulSet.
+## Custom labels to add to the Zulip StatefulSet.
 statefulSetLabels: {}
-# -- Custom annotations to add to the Zulip StatefulSet.
+## Custom annotations to add to the Zulip StatefulSet.
 statefulSetAnnotations: {}
 
-# -- Custom labels to add to the Zulip Pod.
+##  Custom labels to add to the Zulip Pod.
 podLabels: {}
-# -- Custom annotations to add to the Zulip Pod.
+## Custom annotations to add to the Zulip Pod.
 podAnnotations: {}
 
-# -- Can be used to override the default PodSecurityContext (fsGroup, runAsUser
-# and runAsGroup) of the Zulip _Pod_.
+## Can be used to override the default PodSecurityContext (fsGroup,
+## runAsUser and runAsGroup) of the Zulip _Pod_.
 podSecurityContext:
   {}
   # fsGroup: 1000
   # runAsUser: 1000
   # runAsGroup: 1000
 
-# -- Can be used to override the default SecurityContext of the Zulip _container_.
+## Can be used to override the default SecurityContext of the Zulip _container_.
 securityContext:
   {}
   # capabilities:
@@ -63,30 +65,31 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# -- Service type and port for the Kubernetes service that connects to Zulip.
-# Default: ClusterIP, needs an Ingress to be used.
+## Service type and port for the Kubernetes service that connects to
+## Zulip. Default of ClusterIP needs an Ingress to be used.
 service:
   type: ClusterIP
   port: 80
 
 ingress:
-  # -- Enable this to use an Ingress to reach the Zulip service.
+  ## Enable this to use an Ingress to reach the Zulip service.
   enabled: false
-  # -- Can be used to add custom Ingress annotations.
+  ## Can be used to add custom Ingress annotations.
   annotations:
     {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    # -- Host for the Ingress. Should be the same as
-    # `zulip.environment.SETTING_EXTERNAL_HOST`.
+    ## Host for the Ingress. Should be the same as
+    ## `zulip.environment.SETTING_EXTERNAL_HOST`.
     - host: zulip.example.com
-      # -- Serves Zulip root of the chosen host domain.
+      ## Serves Zulip root of the chosen host domain.
       paths:
         - path: /
-  # -- Set a specific secret to read the TLS certificate from. If you use
-  # cert-manager, it will save the TLS secret here. If you do not, you need to
-  # manually create a secret with your TLS certificate.
+  ## Set a specific secret to read the TLS certificate from. If you
+  ## use cert-manager, it will save the TLS secret here. If you do
+  ## not, you need to manually create a secret with your TLS
+  ## certificate.
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -94,10 +97,12 @@ ingress:
 
 resources:
   {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## We usually recommend not to specify default resources and to
+  ## leave this as a conscious choice for the user. This also
+  ## increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources,
+  ## uncomment the following lines, adjust them as necessary, and
+  ## remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -105,32 +110,33 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-# -- Optionally add a nodeSelector to the Zulip pod, so it runs on a specific
-# node.
-# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+## Optionally add a nodeSelector to the Zulip pod, so it runs on a specific
+## node.
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
-# -- Tolerations for pod assignment.
-# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## Tolerations for pod assignment.
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
-# -- Affinity for pod assignment.
-# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Affinity for pod assignment.
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
 zulip:
-  # Environment variables based on https://github.com/zulip/docker-zulip/blob/master/docker-compose.yml#L63
+  ## Environment variables based on
+  ## https://github.com/zulip/docker-zulip/blob/master/docker-compose.yml#L63
   environment:
-    # -- Disables HTTPS if set to "true".
-    # HTTPS and certificates are managed by the Kubernetes cluster, so
-    # by default it's disabled inside the container
+    ## Disable the default Zulip requirement of HTTPS.  HTTPS and
+    ## certificates are managed by the Kubernetes cluster, so by
+    ## default it's disabled inside the container.
     DISABLE_HTTPS: true
-    # -- Set SSL certificate generation to self-signed because Kubernetes
-    # manages the client-facing SSL certs.
+    ## Set SSL certificate generation to self-signed because
+    ## Kubernetes manages the client-facing SSL certs.
     SSL_CERTIFICATE_GENERATION: self-signed
-    # -- Domain Zulip is hosted on.
+    ## Domain Zulip is hosted on.
     SETTING_EXTERNAL_HOST: zulip.example.com
-    # -- SMTP email password.
+    ## SMTP email password.
     SECRETS_email_password: "123456789"
     SETTING_ZULIP_ADMINISTRATOR: "admin@example.com"
     SETTING_EMAIL_HOST: "" # e.g. smtp.example.com
@@ -139,18 +145,19 @@ zulip:
     SETTING_EMAIL_USE_SSL: "False"
     SETTING_EMAIL_USE_TLS: "True"
     ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
-  # -- If `persistence.existingClaim` is not set, a PVC is generated with these
-  # specifications.
+  ## If `persistence.existingClaim` is not set, a PVC (Persistent
+  ## Volume Claim) is generated with these specifications.
   persistence:
     enabled: true
     accessMode: ReadWriteOnce
     size: 10Gi
-    # -- Set storageClass to use.
+    ## Set storageClass to use.
     storageClass:
-    # existingClaim: "" # Use an already existing PVC
+    ## Use an already existing PVC
+    # existingClaim: ""
 
-# -- Liveness probe values.
-# Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## Liveness probe values.
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 livenessProbe:
   enabled: true
   initialDelaySeconds: 10
@@ -158,8 +165,8 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 3
   successThreshold: 1
-# -- Startup probe values.
-# Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## Startup probe values.
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 startupProbe:
   enabled: true
   initialDelaySeconds: 10
@@ -169,18 +176,18 @@ startupProbe:
   successThreshold: 1
 
 postSetup:
-  # -- The Docker entrypoint script runs commands from `/data/post-setup.d` after
-  # the Zulip application's Setup phase has completed. Scripts can be added here
-  # as `script_filename: <script contents>` and they will be mounted in
-  # `/data/post-setup.d/script_filename`.
+  ## The Docker entrypoint script runs commands from `/data/post-setup.d` after
+  ## the Zulip application's Setup phase has completed. Scripts can be added here
+  ## as `script_filename: <script contents>` and they will be mounted in
+  ## `/data/post-setup.d/script_filename`.
   scripts:
     {}
     # scriptName.sh: |
     #   #!/bin/bash
-    #   echo "This is a script that gets executed in the Zulip container after installation, once migrations are complete"
+    #   echo "This script is executed in the Zulip container after installation/migrations."
 
-  # -- You can add any sidecar to Zulip, like a minio client to use for
-  # uploading backups to a bucket, and mounting the volume for Zulip.
+  ## You can add any sidecar to Zulip, like a minio client to use for
+  ## uploading backups to a bucket, and mounting the volume for Zulip.
   # sidecars:
   #   - image: minio/mc
   #     name: minio-client
@@ -190,12 +197,12 @@ postSetup:
 sidecars:
   []
 
-# -- PostgreSQL settings, see [Requirements](#Requirements).
+## PostgreSQL settings, see [Requirements](#Requirements).
 postgresql:
   primary:
     containerSecurityContext:
       runAsUser: 0
-  # We need to override the Postgresql image to get all the plugins Zulip needs
+  ## We need to override the Postgresql image to get all the plugins Zulip needs
   image:
     repository: zulip/zulip-postgresql
     tag: 14
@@ -203,19 +210,19 @@ postgresql:
     username: zulip
     database: zulip
 
-# -- Rabbitmq settings, see [Requirements](#Requirements).
+## Rabbitmq settings, see [Requirements](#Requirements).
 rabbitmq:
   auth:
     username: zulip
-  # Set this to true if you need the rabbitmq to be persistent
+  ## Set this to true if you need the rabbitmq to be persistent
   persistence:
     enabled: false
 
-# -- Memcached settings, see [Requirements](#Requirements).
+## Memcached settings, see [Requirements](#Requirements).
 memcached:
   memcachedUsername: "zulip@localhost"
 
-# -- Redis settings, see [Requirements](#Requirements).
+## Redis settings, see [Requirements](#Requirements).
 redis:
   architecture: standalone
   master:

--- a/kubernetes/manual/zulip-rc.yml
+++ b/kubernetes/manual/zulip-rc.yml
@@ -92,7 +92,8 @@ spec:
               cpu: 100m
               memory: 3584Mi
           env:
-            # Please take a look at the environment variables in docker-compose.yml for all required env variables!
+            ## Please take a look at the environment variables in
+            ## docker-compose.yml for all required env variables!
             - name: DB_HOST
               value: "localhost"
             - name: MEMCACHED_HOST
@@ -110,7 +111,7 @@ spec:
             - name: SETTING_ZULIP_ADMINISTRATOR
               value: "admin@example.com"
             - name: SETTING_EMAIL_HOST
-              value: "" # E.g. 'smtp.example.com'
+              value: ""
             - name: SETTING_EMAIL_HOST_USER
               value: "noreply@example.com"
             - name: ZULIP_USER_EMAIL
@@ -121,7 +122,7 @@ spec:
               value: "123456789"
             - name: SECRETS_secret_key
               value: "REPLCAE_WITH_SECURE_SECRET_KEY"
-            # These should match the passwords configured above
+            ## These should match the passwords configured above
             - name: SECRETS_postgres_password
               value: "REPLACE_WITH_SECURE_POSTGRES_PASSWORD"
             - name: SECRETS_memcached_password
@@ -132,7 +133,7 @@ spec:
               value: "REPLACE_WITH_SECURE_REDIS_PASSWORD"
             - name: SSL_CERTIFICATE_GENERATION
               value: "self-signed"
-          # Uncomment this when configuring the mobile push notifications service
+          ## Uncomment this when configuring the mobile push notifications service
           # - name: SETTING_PUSH_NOTIFICATION_BOUNCER_URL
           #   value: 'https://push.zulipchat.com'
           ports:


### PR DESCRIPTION
- Rewrite the intro and headings
- Move the "Docker data model" section down and provide a more useful transition.
- Update comment style in YAML files to use `##` for prose, making text stand out.
- Fix a few documentation gaps.