### PR TITLE
supporting exposing https port

### DIFF
--- a/kubernetes/chart/zulip/templates/service.yaml
+++ b/kubernetes/chart/zulip/templates/service.yaml
@@ -8,7 +8,11 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      {{- if .Values.zulip.environment.DISABLE_HTTPS }}
       targetPort: http
+      {{- else }}
+      targetPort: https
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/kubernetes/chart/zulip/templates/statefulset.yaml
+++ b/kubernetes/chart/zulip/templates/statefulset.yaml
@@ -50,6 +50,9 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
           volumeMounts:
             - name: {{ include "zulip.fullname" . }}-persistent-storage
               mountPath: /data


### PR DESCRIPTION
This PR allows for expose https port based on `DISABLE_HTTPS` config.

The rationale is, I've tried to deploy the chart using an ingress and found it complicated to configure the proper whitelists for the proxy chain of trust. All to end up with a setup where the segment between zulip and the ingress controller passes in the clear.

With this simple modification I don't change the previous chart's behaviour but I can configure my ingress to use https eg. by annotating it in values file:

```yaml
ingress:
  enabled: true
  annotations:
    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
[...]
```

and this produce an easy to obtain end-to-end encryption and zero fights with the container setup!

**How did you test this PR?**

```diff
$ diff -u \
 <(helm template zulip . -s templates/service.yaml) \
 <(helm template zulip . --set=zulip.environment.DISABLE_HTTPS=false -s templates/service.yaml)
--- /proc/self/fd/11    2024-12-28 14:54:57.416000000 +0100
+++ /proc/self/fd/22    2024-12-28 14:54:57.416000000 +0100
@@ -14,7 +14,7 @@
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: http
+      targetPort: https
       protocol: TCP
       name: http
   selector:

```

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

Hope this helps, ciao and thank you!