### PR TITLE
support env vars from an existing secret

### DIFF
--- a/kubernetes/chart/zulip/templates/NOTES.txt
+++ b/kubernetes/chart/zulip/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. To create a realm so you can sign in:
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "zulip.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl -n {{ .Release.Namespace }} exec -it "$POD_NAME" -c zulip -- sudo -u zulip /home/zulip/deployments/current/manage.py generate_realm_creation_link
+  kubectl -n {{ .Release.Namespace }} exec -it "$POD_NAME" -c zulip -- sudo -Eu zulip /home/zulip/deployments/current/manage.py generate_realm_creation_link
 
 2. Zulip will be available on:
 

--- a/kubernetes/chart/zulip/templates/_helpers.tpl
+++ b/kubernetes/chart/zulip/templates/_helpers.tpl
@@ -78,16 +78,26 @@ include all env variables for Zulip pods
   value: "{{ template "common.names.fullname" .Subcharts.rabbitmq }}"
 - name: SETTING_REDIS_HOST
   value: "{{ template "common.names.fullname" .Subcharts.redis }}-headless"
+{{- if .Values.rabbitmq.auth.password }}
 - name: SECRETS_rabbitmq_password
   value: "{{ .Values.rabbitmq.auth.password }}"
+{{- end }}
+{{- if .Values.postgresql.auth.password }}
 - name: SECRETS_postgres_password
   value: "{{ .Values.postgresql.auth.password }}"
+{{- end }}
+{{- if .Values.memcached.memcachedPassword }}
 - name: SECRETS_memcached_password
   value: "{{ .Values.memcached.memcachedPassword }}"
+{{- end }}
+{{- if .Values.redis.auth.password }}
 - name: SECRETS_redis_password
   value: "{{ .Values.redis.auth.password }}"
+{{- end }}
+{{- if .Values.zulip.password }}
 - name: SECRETS_secret_key
   value: "{{ .Values.zulip.password }}"
+{{- end }}
 {{- range $key, $value := .Values.zulip.environment }}
 - name: {{ $key }}
   value: {{ $value | quote }}

--- a/kubernetes/chart/zulip/templates/statefulset.yaml
+++ b/kubernetes/chart/zulip/templates/statefulset.yaml
@@ -57,6 +57,11 @@ spec:
               mountPath: /data/post-setup.d
           env:
             {{ include "zulip.env" . | nindent 12 }}
+          {{- if .Values.zulip.secretEnvironment }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.zulip.secretEnvironment }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.livenessProbe.enabled }}

--- a/kubernetes/chart/zulip/values.yaml
+++ b/kubernetes/chart/zulip/values.yaml
@@ -145,6 +145,8 @@ zulip:
     SETTING_EMAIL_USE_SSL: "False"
     SETTING_EMAIL_USE_TLS: "True"
     ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
+  ## An existing secret from which populate environment variablgwes.
+  secretEnvironment: ""
   ## If `persistence.existingClaim` is not set, a PVC (Persistent
   ## Volume Claim) is generated with these specifications.
   persistence:


### PR DESCRIPTION
This simple one allows to inject environment variables from an existing secret, which is a very common pattern when using helm and let users stick to their k8s workflow. Also, keeping plaintext secrets in values file is an ultimate blocker for zulip adoption where I work.

I don't see any concern about this change, especially in respect of not changing anything in docker image inner workings but only simplifying our k8s life :)

**How did you test this PR?**

```diff
$ diff -u \
 <(helm template zulip . -s templates/statefulset.yaml) \
 <(helm template zulip . --set=zulip.secretEnvironment=my-secret -s templates/statefulset.yaml)
--- /proc/self/fd/11    2024-12-28 15:31:19.264000000 +0100
+++ /proc/self/fd/22    2024-12-28 15:31:19.264000000 +0100
@@ -86,6 +86,9 @@
               value: "self-signed"
             - name: ZULIP_AUTH_BACKENDS
               value: "EmailAuthBackend"
+          envFrom:
+            - secretRef:
+                name: my-secret
           resources:
             {}
           livenessProbe:
```

Hope this helps, ciao!
