### PR TITLE
easy smokescreen address whitelist

### DIFF
--- a/kubernetes/chart/zulip/templates/cm-post-setup-scripts.yaml
+++ b/kubernetes/chart/zulip/templates/cm-post-setup-scripts.yaml
@@ -9,4 +9,14 @@ data:
   {{ $scriptName }}: |
     {{- $scriptContents | nindent 4 }}
   {{- end }}
+  {{- if .Values.zulip.smokeScreen.whitelistedAddresses }}
+  __zulip_smokescreen_whitelist.sh: |
+    #!/bin/bash
 
+    sed -ri \
+        "s/(command.*)/\1
+        {{- range .Values.zulip.smokeScreen.whitelistedAddresses }} --allow-address {{ . }}{{ end -}}
+        /" \
+        /etc/supervisor/conf.d/zulip/smokescreen.conf
+
+  {{- end }}

--- a/kubernetes/chart/zulip/values.yaml
+++ b/kubernetes/chart/zulip/values.yaml
@@ -124,6 +124,9 @@ tolerations: []
 affinity: {}
 
 zulip:
+  smokeScreen:
+    # a list of whitelisted ip for smokescreen
+    whitelistedAddresses: []
   ## Environment variables based on
   ## https://github.com/zulip/docker-zulip/blob/master/docker-compose.yml#L63
   environment:


### PR DESCRIPTION
This PR helped me solving the problem we face with smokescreen when some of your services are on a private network. Entirely disabling it does not looks like a good idea, plus I did not manage to do that because everything broke when I added the usual:

```ini
[proxy]
host = 
```

thing. So! This uses dockerfile's entrypoint `runPostSetupScripts` and allows me to list my whitelisted addressed so everything works well!

**How did you test this PR?**

```diff
$ diff -u \
 <(helm template zulip . -s templates/cm-post-setup-scripts.yaml) \
 <(helm template zulip . \
      --set-json=zulip.smokeScreen.whitelistedAddresses='["1.2.3.4", "11.22.33.44"]' \
      -s templates/cm-post-setup-scripts.yaml)
--- /proc/self/fd/11    2024-12-28 15:55:37.660000000 +0100
+++ /proc/self/fd/22    2024-12-28 15:55:37.660000000 +0100
@@ -11,3 +11,9 @@
     app.kubernetes.io/version: "9.3-0"
     app.kubernetes.io/managed-by: Helm
 data:
+  __zulip_smokescreen_whitelist.sh: |
+    #!/bin/bash
+
+    sed -ri \
+        "s/(command.*)/\1 --allow-address 1.2.3.4 --allow-address 11.22.33.44/" \
+        /etc/supervisor/conf.d/zulip/smokescreen.conf

```

Hope this helps, ciao!