### PR TITLE
env map value

### DIFF
--- a/kubernetes/chart/zulip/README.md
+++ b/kubernetes/chart/zulip/README.md
@@ -144,6 +144,19 @@ variables are forwarded to the Docker container, you can read more about
 configuring Zulip through environment variables
 [here](https://github.com/zulip/docker-zulip/#configuration).
 
+Variables can be either a plain scalar value (i.e., a string or
+integer), or a projected value from a secret or configmap.  For
+example:
+
+```yaml
+SETTING_EXTERNAL_HOST: zulip.example.com
+SECRETS_email_password:
+  valueFrom:
+    secretKeyRef:
+      name: email
+      key: password
+```
+
 ### Dependencies
 
 The chart uses Memcached, RabbitMQ and Redis helm charts defined in

--- a/kubernetes/chart/zulip/templates/_helpers.tpl
+++ b/kubernetes/chart/zulip/templates/_helpers.tpl
@@ -90,6 +90,10 @@ include all env variables for Zulip pods
   value: "{{ .Values.zulip.password }}"
 {{- range $key, $value := .Values.zulip.environment }}
 - name: {{ $key }}
+  {{- if kindIs "map" $value }}
+  {{- toYaml $value | nindent 2 }}
+  {{- else }}
   value: {{ $value | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Ciao, this PR exploits the possibilities of kubernetes to more richly express secrets in the environment by using secrets/configmap projections. 
It is inobtrusive as it only mangle `map`s leaving any other value alone.

```yaml
helm template zulip . \
  --set zulip.environment.SECRETS_email_password=password \
  --set-json zulip.environment.SECRETS_password='
    {"valueFrom":{"secretKeyRef":{"name": "secret", "key": "key"}}}' \
  -s templates/statefulset.yaml \
| yq -Y '.spec.template.spec.containers[] .env[] 
         | select((.name=="SETTING_EXTERNAL_HOST") 
                  or .name=="SECRETS_password")'

- name: SECRETS_email_password
  value: "password"
- name: SECRETS_password
  valueFrom:
    secretKeyRef:
      key: key
      name: secret
```

This easily unlocks the possibility to specify existing secrets in env vars without defining a dedicated one and going the #482 way. It does not breaks current workflow, but enable whoever want to do that to have it :)


Hope this helps, ciao!