### PR TITLE
docker-compose.yml SETTINGS_ env var family typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,13 +105,13 @@ services:
       ##   https://zulip.readthedocs.io/en/latest/production/upload-backends.html
       ##
       ## If you want to use the S3 backend, you must set
-      ## SETTINGS_LOCAL_UPLOADS_DIR to None as well as configuring the
+      ## SETTING_LOCAL_UPLOADS_DIR to None as well as configuring the
       ## other fields.
-      # SETTINGS_LOCAL_UPLOADS_DIR: "None"
-      # SETTINGS_S3_AUTH_UPLOADS_BUCKET: ""
-      # SETTINGS_S3_AVATAR_BUCKET: ""
-      # SETTINGS_S3_ENDPOINT_URL: "None"
-      # SETTINGS_S3_REGION: "None"
+      # SETTING_LOCAL_UPLOADS_DIR: "None"
+      # SETTING_S3_AUTH_UPLOADS_BUCKET: ""
+      # SETTING_S3_AVATAR_BUCKET: ""
+      # SETTING_S3_ENDPOINT_URL: "None"
+      # SETTING_S3_REGION: "None"
     volumes:
       - "zulip:/data:rw"
     ulimits:


### PR DESCRIPTION
SETTINGS_ prefixed env vars don't end up in settings

I believe you meant SETTING_ : those properly end up in settings

e.g. bucket names ain't empty when I run `docker exec -u zulip -it docker-zulip-zulip-1 bash -l -c "/home/zulip/deployments/current/manage.py transfer_uploads_to_s3"`

Fixes: ?

**How did you test this PR?**

transfer_uploads_to_s3 script works now

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
