### PR TITLE
Update path used to activate venv.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ARG CUSTOM_CA_CERTIFICATES
 
 # Finally, we provision the development environment and build a release tarball
 RUN SKIP_VENV_SHELL_WARNING=1 ./tools/provision --build-release-tarball-only
-RUN . /srv/zulip-py3-venv/bin/activate && \
+RUN . ./.venv/bin/activate && \
     ./tools/build-release-tarball docker && \
     mv /tmp/tmp.*/zulip-server-docker.tar.gz /tmp/zulip-server-docker.tar.gz
 


### PR DESCRIPTION
Needs to be updated due to
https://github.com/zulip/zulip/commit/d7556b40606364b0ac3c55512b43ad086d937c3b

