### PR TITLE
docker-compose: stop zulip before db,redis,etc.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,11 @@ services:
       nofile:
         soft: 1000000
         hard: 1048576
+    depends_on:
+      - database
+      - memcached
+      - rabbitmq
+      - redis
 volumes:
   zulip:
   postgresql-14:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: RabbitMQ errors on shutdown of the service.
```
[Django] ERROR: Unhandled exception from queue: xxxxxxx
Exception Type: ConnectionClosedByBroker
Exception Value: (320, "CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'")
```

I get a 2-5 Django emails each time I restart the service because RabbitMQ's container stops significantly faster than Zulip's. This results in the above error.

This small PR forces the other containers to wait until zulip's container is finished shutting down before they can stop.

This PR is technically overbroad for the issue. I could just set Zulip to depend on RabbitMQ, but logically Zulip does depend on all of these containers and Zulip probably expects to be able to access all of them while shutting down.

The one drawback I can think of is that shutdowns will be slightly slower because other containers will have to wait for Zulip to shut down first. However, it's a small difference in my testing and I think it's a sane default.

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
