### PR TITLE
Add ingressClassName field to Ingress Helm template

### DIFF
--- a/kubernetes/chart/zulip/README.md
+++ b/kubernetes/chart/zulip/README.md
@@ -79,6 +79,7 @@ Now you're ready to follow [the installation instructions above](#installation).
 | ingress.enabled                                                    | bool   | `false`                     |             |
 | ingress.hosts[0].host                                              | string | `"zulip.example.com"`       |             |
 | ingress.hosts[0].paths[0].path                                     | string | `"/"`                       |             |
+| ingress.ingressClassName                                           | string | `""`                        |             |
 | ingress.tls                                                        | list   | `[]`                        |             |
 | livenessProbe.enabled                                              | bool   | `true`                      |             |
 | livenessProbe.failureThreshold                                     | int    | `3`                         |             |

--- a/kubernetes/chart/zulip/templates/ingress.yaml
+++ b/kubernetes/chart/zulip/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/kubernetes/chart/zulip/values.yaml
+++ b/kubernetes/chart/zulip/values.yaml
@@ -74,6 +74,8 @@ service:
 ingress:
   ## Enable this to use an Ingress to reach the Zulip service.
   enabled: false
+  ## Ingress class name to use.
+  ingressClassName: ""
   ## Can be used to add custom Ingress annotations.
   annotations:
     {}


### PR DESCRIPTION
Many configurations require this field to be set, so just adding it here. `kubernetes.io/ingress.class` has been deprecated since 1.22.

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

I need this for my local deploy, so tested it with that and it works fine.

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
