### PR TITLE
entrypoint: Replace `checkconfig` command with `check`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -353,7 +353,7 @@ zulipConfiguration() {
         fi
         setConfigurationValue "$setting_key" "$setting_var" "$type"
     done
-    if ! su zulip -c "/home/zulip/deployments/current/manage.py checkconfig"; then
+    if ! su zulip -c "/home/zulip/deployments/current/manage.py check"; then
         echo "Error in the Zulip configuration. Exiting."
         exit 1
     fi


### PR DESCRIPTION
To sync with https://github.com/zulip/zulip/commit/6c9705a6bb784a9be5f2a79b2b454588d32d979a

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
```
zulip-1  | Executing Zulip configuration ...
zulip-1  | Setting key "ADD_TOKENS_TO_NOREPLY_ADDRESS", type "bool".
zulip-1  | Setting key "CSRF_TRUSTED_ORIGINS", type "array".
zulip-1  | Setting key "EMAIL_GATEWAY_IMAP_PORT", type "integer".
zulip-1  | Setting key "EMAIL_GATEWAY_IMAP_SERVER", type "string".
zulip-1  | Setting key "EMAIL_GATEWAY_LOGIN", type "string".
zulip-1  | Setting key "EMAIL_GATEWAY_PATTERN", type "string".
zulip-1  | Setting key "EMAIL_HOST", type "string".
zulip-1  | Setting key "EMAIL_HOST_USER", type "string".
zulip-1  | Setting key "EMAIL_PORT", type "integer".
zulip-1  | Setting key "EMAIL_USE_SSL", type "bool".
zulip-1  | Setting key "EMAIL_USE_TLS", type "bool".
zulip-1  | Setting key "EXTERNAL_HOST", type "string".
zulip-1  | Setting key "MAX_FILE_UPLOAD_SIZE", type "integer".
zulip-1  | Setting key "MEMCACHED_LOCATION", type "string".
zulip-1  | Setting key "NOREPLY_EMAIL_ADDRESS", type "string".
zulip-1  | Setting key "RABBITMQ_HOST", type "string".
zulip-1  | Setting key "RABBITMQ_USER", type "string".
zulip-1  | Setting key "REDIS_HOST", type "string".
zulip-1  | Setting key "REDIS_PORT", type "integer".
zulip-1  | Setting key "SOCIAL_AUTH_GITHUB_KEY", type "string".
zulip-1  | Setting key "WEB_PUBLIC_STREAMS_ENABLED", type "bool".
zulip-1  | Setting key "ZULIP_ADMINISTRATOR", type "string".
zulip-1  | Unknown command: 'checkconfig'. Did you mean check?
zulip-1  | Type 'manage.py help' for usage.
zulip-1  | Error in the Zulip configuration. Exiting.
zulip-1 exited with code 1 (restarting)
```
<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
