### PR TITLE
entrypoint: Switch to manage.py check, from checkconfig.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -353,7 +353,7 @@ zulipConfiguration() {
         fi
         setConfigurationValue "$setting_key" "$setting_var" "$type"
     done
-    if ! su zulip -c "/home/zulip/deployments/current/manage.py checkconfig"; then
+    if ! su zulip -c "/home/zulip/deployments/current/manage.py check"; then
         echo "Error in the Zulip configuration. Exiting."
         exit 1
     fi
@@ -404,7 +404,7 @@ initialConfiguration() {
             ls -l /etc/zulip/
             exit 1
         fi
-        if ! su zulip -c "/home/zulip/deployments/current/manage.py checkconfig"; then
+        if ! su zulip -c "/home/zulip/deployments/current/manage.py check"; then
             echo "Error in the Zulip configuration. Exiting."
             exit 1
         fi


### PR DESCRIPTION
The latter is Zulip-specific, and being removed in `main`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
