### PR TITLE
entrypoint: Fix QUEUE_WORKERS_MULTIPROCESS=False override.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ normalize_bool() {
     local varname="$1"
     local raw_value="${!varname:-}"
     local value="${raw_value,,}" # Convert to lowercase
-    local default="${2:-False}"
+    local default="${2-False}"   # Only default if not provided; explicit "" is a valid default
 
     case "$value" in
         true | enable | enabled | yes | y | 1 | on)
@@ -66,7 +66,7 @@ PROXY_ALLOW_RANGES="${PROXY_ALLOW_RANGES:-}"
 
 # Core Zulip settings
 ZULIP_AUTH_BACKENDS="${ZULIP_AUTH_BACKENDS:-EmailAuthBackend}"
-QUEUE_WORKERS_MULTIPROCESS="$(normalize_bool QUEUE_WORKERS_MULTIPROCESS)"
+QUEUE_WORKERS_MULTIPROCESS="$(normalize_bool QUEUE_WORKERS_MULTIPROCESS '')"
 
 # Configuration controls
 FORCE_FIRST_START_INIT="$(normalize_bool FORCE_FIRST_START_INIT)"
@@ -163,7 +163,7 @@ puppetConfiguration() {
     if [ "$QUEUE_WORKERS_MULTIPROCESS" == "True" ]; then
         echo "Setting queue workers to run in multiprocess mode ..."
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess true
-    else
+    elif [ "$QUEUE_WORKERS_MULTIPROCESS" == "False" ]; then
         echo "Setting queue workers to run in multithreaded mode ..."
         crudini --set /etc/zulip/zulip.conf application_server queue_workers_multiprocess false
     fi


### PR DESCRIPTION
9ebfc936ff0c mistakenly both removed the `elif` check and added an implicit `False` default for QUEUE_WORKERS_MULTIPROCESS.  This made the Docker deployment always default to
QUEUE_WORKERS_MULTIPROCESS=False, as opposed to using the standard Zulip logic of examining the memory overhead.

Return the previous behaviour, where the logic can be overridden in either direction.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
