### PR TITLE
Fix postgres host

### DIFF
--- a/helm/zulip/values.yaml
+++ b/helm/zulip/values.yaml
@@ -145,6 +145,8 @@ zulip:
     SETTING_EMAIL_USE_TLS: "True"
     SECRETS_email_password: "123456789"
     ZULIP_AUTH_BACKENDS: "EmailAuthBackend"
+    ## Database
+    SETTING_REMOTE_POSTGRES_HOST: "zulip-postgresql"
   ## If `persistence.existingClaim` is not set, a PVC (Persistent
   ## Volume Claim) is generated with these specifications.
   persistence:


### PR DESCRIPTION
Using helm chart, the default config does not work, after 3-hours of investigation, i found out that the issue is here:
https://github.com/zulip/docker-zulip/blob/08c58e1b2cb346071958738fd349dc4e7f1db217/entrypoint.sh#L454

This line returns `127.0.0.1` and in kubernetes `pg_isready` is not gonna work, it should see the service name which is `zulip-postgresql`.

I've added that into `values.yaml` since it's required. if you think there is a better way to do this let me know.