### PR TITLE
compose: add ports docs cross-reference

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -69,6 +69,10 @@ services:
     build:
       context: .
     ports:
+      # See the TLS/reverse proxy docs before changing the HTTP/HTTPS ports:
+      # https://zulip.readthedocs.io/projects/docker/en/latest/how-to/compose-ssl.html
+      # See the incoming email docs before changing the SMTP port:
+      # https://zulip.readthedocs.io/projects/docker/en/latest/how-to/compose-incoming-email.html
       - name: smtp
         target: 25
         published: 25


### PR DESCRIPTION
## Summary
- add a short comment above the default published ports in compose.yaml
- point readers to the networking and reverse proxy documentation before changing those mappings

## Testing
- not run (documentation/comment-only change)

Closes #515.