### PR TITLE
docs: Add a Compose backups how-to, mirroring helm-persistence.

### DIFF
--- a/ci/backup-restore-volume/compose.yaml
+++ b/ci/backup-restore-volume/compose.yaml
@@ -1,0 +1,3 @@
+---
+services:
+  zulip: {}

--- a/ci/backup-restore-volume/test.sh
+++ b/ci/backup-restore-volume/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+# Disaster-recovery restore from a volume tarball onto a clean-slate
+# deployment.  Use case: the host died and we're rebuilding from a
+# tarball that has the full /data contents and the `app:backup` dump
+# file inside it.  Matches docs/how-to/compose-backups.md.
+#
+# See ci/backup-restore/ for the simpler in-place flow.
+
+# Set up state and take a backup; then create more state that the
+# restore should discard.
+"${manage[@]:?}" create_realm 'Testing Realm' admin@example.com 'Test Admin' --password very-secret
+"${docker[@]:?}" exec zulip /sbin/entrypoint.sh app:backup
+"${manage[@]}" create_realm 'Other Realm' admin@example.com 'Test Admin' --password very-secret --string-id other
+
+# Tar the volume contents out.
+"${docker[@]}" run --rm -v zulip:/data -v "$(pwd)":/backup zulip \
+    tar czf /backup/zulip-volume.tar.gz -C /data .
+
+# Wipe everything, including all named volumes -- the disaster.
+"${docker[@]}" down -v
+
+# Restore the volume contents into a fresh `zulip` volume; the
+# `run --rm` creates the named volume implicitly.
+"${docker[@]}" run --rm -v zulip:/data -v "$(pwd)":/backup zulip \
+    tar xzf /backup/zulip-volume.tar.gz -C /data
+
+# Bring services back up.  initialConfiguration regenerates
+# /etc/zulip/settings.py from the env vars and migrates the fresh
+# database to the latest schema.
+"${docker[@]}" up -d --wait
+
+# Restore the database from the dump in the restored `/data/backups/`.
+backup_file=$("${docker[@]}" exec zulip ls /data/backups/ | sort | head -n1)
+"${docker[@]}" exec zulip /sbin/entrypoint.sh app:restore "$backup_file"
+
+# Verify the data made the round trip: "Testing Realm" is back,
+# "Other Realm" (which existed only after the backup) is gone.
+"${manage[@]}" list_realms | grep "Testing Realm"
+if "${manage[@]}" list_realms | grep "Other Realm"; then
+    exit 1
+fi

--- a/ci/backup-restore-volume/test.sh
+++ b/ci/backup-restore-volume/test.sh
@@ -25,17 +25,14 @@ set -o pipefail
 
 # Restore the volume contents into a fresh `zulip` volume; the
 # `run --rm` creates the named volume implicitly.
-"${docker[@]}" run --rm -v zulip:/data -v "$(pwd)":/backup zulip \
+"${docker[@]}" run --rm --no-deps -v zulip:/data -v "$(pwd)":/backup zulip \
     tar xzf /backup/zulip-volume.tar.gz -C /data
 
-# Bring services back up.  initialConfiguration regenerates
-# /etc/zulip/settings.py from the env vars and migrates the fresh
-# database to the latest schema.
-"${docker[@]}" up -d --wait
-
 # Restore the database from the dump in the restored `/data/backups/`.
-backup_file=$("${docker[@]}" exec zulip ls /data/backups/ | sort | head -n1)
-"${docker[@]}" exec zulip /sbin/entrypoint.sh app:restore "$backup_file"
+backup_file=$("${docker[@]}" run --rm --no-deps zulip ls /data/backups/ | sort | head -n1)
+"${docker[@]}" run --rm zulip app:restore "$backup_file"
+
+"${docker[@]}" up -d --wait
 
 # Verify the data made the round trip: "Testing Realm" is back,
 # "Other Realm" (which existed only after the backup) is gone.

--- a/ci/backup-restore/test.sh
+++ b/ci/backup-restore/test.sh
@@ -3,6 +3,12 @@
 set -eux
 set -o pipefail
 
+# In-place restore against an already-configured, running deployment.
+# Use case: undo an "oops" -- a bad upgrade, a mistaken migration, or
+# anything else where the volume and surrounding services are healthy
+# and the only thing wrong is the database state.  See
+# ci/backup-restore-volume/ for the disaster-recovery flow.
+
 # One realm, one backup
 "${manage[@]:?}" create_realm 'Testing Realm' admin@example.com 'Test Admin' --password very-secret
 "${docker[@]:?}" exec zulip /sbin/entrypoint.sh app:backup

--- a/ci/backup-restore/test.sh
+++ b/ci/backup-restore/test.sh
@@ -38,3 +38,10 @@ first_backup=$("${docker[@]}" exec zulip ls /data/backups/ | sort | head -n1)
 if "${manage[@]}" list_realms | grep "Other Realm"; then
     exit 1
 fi
+
+# `run --rm app:restore` against the running stack should refuse,
+# since the live workers are holding persistent DB connections.
+if "${docker[@]}" run --rm zulip app:restore "$first_backup"; then
+    echo "FAIL: run --rm app:restore did not refuse against live stack"
+    exit 1
+fi

--- a/docs/how-to/compose-backups.md
+++ b/docs/how-to/compose-backups.md
@@ -42,31 +42,31 @@ docker compose cp zulip:/data/backups/ ./backups/
 
 ## Restore from a backup
 
-Stop the Zulip container, restore the volume contents from the
-tarball, then bring it back up:
+With the stack stopped (or before bringing it up for the first time
+on this host), untar the backup volume into a fresh `zulip` named
+volume and restore the database from the dump inside it:
 
 ```bash
-docker compose stop zulip
-docker compose run --rm -v zulip:/data -v $(pwd):/backup zulip \
+docker compose down -v               # wipe any existing state on this host
+docker compose run --rm --no-deps -v zulip:/data -v $(pwd):/backup zulip \
   tar xzf /backup/backup.tar.gz -C /data
-docker compose up -d zulip
+docker compose run --rm zulip app:restore <filename>
+docker compose up -d --wait
 ```
 
-The volume restore brings back uploads, configuration, certificates,
-and the database dump in `/data/backups/`. The PostgreSQL data in
-the `database` service's `postgresql-14` volume is _not_ touched by
-this; to bring the database itself to a matching state, restore from
-the dump inside the volume:
+`<filename>` is one of the `backup-*.sql` files in the restored
+`/data/backups/` directory. See {ref}`app:restore <app-restore>`.
+
+To restore in-place against a running stack (e.g. to undo a bad
+migration), skip the volume restore and use `exec` against the
+running container instead:
 
 ```bash
 docker compose exec zulip /sbin/entrypoint.sh app:restore <filename>
 ```
 
-where `<filename>` is one of the `backup-*.sql` files in the restored
-`/data/backups/` directory. See {ref}`app:restore <app-restore>`.
-
-The container will report unhealthy briefly while `app:restore` is
-in progress, and returns to healthy when the restore completes.
+The container will report unhealthy briefly while the in-place
+restore is in progress, and returns to healthy when it completes.
 
 ## Off-site database backups
 

--- a/docs/how-to/compose-backups.md
+++ b/docs/how-to/compose-backups.md
@@ -65,6 +65,9 @@ docker compose exec zulip /sbin/entrypoint.sh app:restore <filename>
 where `<filename>` is one of the `backup-*.sql` files in the restored
 `/data/backups/` directory. See {ref}`app:restore <app-restore>`.
 
+The container will report unhealthy briefly while `app:restore` is
+in progress, and returns to healthy when the restore completes.
+
 ## Off-site database backups
 
 For continuous off-site database backups independent of the

--- a/docs/how-to/compose-backups.md
+++ b/docs/how-to/compose-backups.md
@@ -1,0 +1,79 @@
+# Compose: Backups
+
+Zulip's persistent state in a Compose deployment lives under the
+`zulip` named Docker volume mounted at `/data`. A snapshot of that
+volume captures everything Zulip needs to restore the deployment —
+uploads, configuration, certificates, secrets, and a recent
+`pg_dump` written into `/data/backups/` by the `app:backup` command.
+See {doc}`/reference/data-volume` for the layout and the full backup
+model.
+
+(compose-volume-snapshot)=
+
+## Take a backup
+
+Refresh the database dump and snapshot the volume, using
+[Docker's recommended pattern for backing up data volumes](https://docs.docker.com/engine/storage/volumes/#back-up-restore-or-migrate-data-volumes):
+
+```bash
+docker compose exec zulip /sbin/entrypoint.sh app:backup
+docker compose run --rm -v zulip:/data -v $(pwd):/backup zulip \
+  tar czf /backup/backup.tar.gz -C /data .
+```
+
+The first command writes a fresh `pg_dump` into `/data/backups/`; the
+second mounts the named volume into an ephemeral container and tars
+its contents out to `backup.tar.gz` in the host's current directory.
+
+`app:backup` also runs on a daily schedule by default (see
+{ref}`auto-backup-enabled` and {ref}`auto-backup-interval`), so the
+volume already holds a reasonably fresh dump for on-demand snapshots;
+the explicit `app:backup` call above just guarantees the dump is as
+current as possible.
+
+## Get just the database dump off-box
+
+If you only need to ship the database dumps off-box, copy them out
+directly:
+
+```bash
+docker compose cp zulip:/data/backups/ ./backups/
+```
+
+## Restore from a backup
+
+Stop the Zulip container, restore the volume contents from the
+tarball, then bring it back up:
+
+```bash
+docker compose stop zulip
+docker compose run --rm -v zulip:/data -v $(pwd):/backup zulip \
+  tar xzf /backup/backup.tar.gz -C /data
+docker compose up -d zulip
+```
+
+The volume restore brings back uploads, configuration, certificates,
+and the database dump in `/data/backups/`. The PostgreSQL data in
+the `database` service's `postgresql-14` volume is _not_ touched by
+this; to bring the database itself to a matching state, restore from
+the dump inside the volume:
+
+```bash
+docker compose exec zulip /sbin/entrypoint.sh app:restore <filename>
+```
+
+where `<filename>` is one of the `backup-*.sql` files in the restored
+`/data/backups/` directory. See {ref}`app:restore <app-restore>`.
+
+## Off-site database backups
+
+For continuous off-site database backups independent of the
+volume-snapshot path, Zulip supports
+{ref}`WAL-based archiving via wal-g <zulip:wal-g>`, which streams
+write-ahead logs to S3 for point-in-time recovery.
+
+## See also
+
+- {doc}`/reference/data-volume`
+- {doc}`/reference/app-commands`
+- {doc}`compose-upgrading`

--- a/docs/how-to/compose-index.md
+++ b/docs/how-to/compose-index.md
@@ -18,4 +18,5 @@ compose-upgrading-from-legacy
 compose-commands
 compose-existing-services
 compose-build
+compose-backups
 ```

--- a/docs/how-to/compose-upgrading.md
+++ b/docs/how-to/compose-upgrading.md
@@ -35,8 +35,7 @@ flow.
      tar czf /backup/backup.tar.gz -C /data .
    ```
 
-   See {doc}`/reference/data-volume` for the underlying backup model
-   and the Helm equivalent.
+   See {doc}`compose-backups` for the full backup-and-restore flow.
 
 1. Check out the release you want to upgrade to, on a local branch
    that you can re-point at each subsequent release. Tag names match

--- a/docs/how-to/helm-persistence.md
+++ b/docs/how-to/helm-persistence.md
@@ -33,6 +33,8 @@ zulip:
 When `existingClaim` is set, the chart does not create a PVC; the StatefulSet
 references the named claim directly.
 
+(helm-volume-snapshot)=
+
 ## Backing up
 
 The PVC mounted at `/data` is the unit of backup. A

--- a/docs/reference/app-commands.md
+++ b/docs/reference/app-commands.md
@@ -61,6 +61,8 @@ volume-snapshot recipes.
 `/data` volume always contains a recent dump for a snapshot to pick
 up.
 
+(app-restore)=
+
 ## `app:restore`
 
 Restores a database from a `pg_dump` archive produced by `app:backup`:

--- a/docs/reference/app-commands.md
+++ b/docs/reference/app-commands.md
@@ -75,7 +75,8 @@ docker compose exec zulip /sbin/entrypoint.sh app:restore <filename>
 omitted, the command prompts interactively. Restore drops and
 recreates existing tables (`pg_restore --clean --if-exists`); a
 10-second countdown precedes the destructive phase so it can be
-aborted with Ctrl-C.
+aborted with Ctrl-C. The Zulip application server is stopped around
+the restore and memcached is flushed afterwards.
 
 To restore the rest of a deployment alongside the database, restore
 the `/data` volume from a snapshot first; the dump file `app:restore`

--- a/docs/reference/app-commands.md
+++ b/docs/reference/app-commands.md
@@ -85,6 +85,14 @@ consumes is one of the files inside that volume. See
 (a different tool with different semantics), see
 {doc}`zulip:production/export-and-import`.
 
+When run from a one-shot container (e.g. `docker compose run --rm
+zulip app:restore <file>`), `app:restore` refuses to proceed if any
+other process is connected to the target database, since those
+connections are most likely live Zulip workers in a sibling
+container that would be left with stale state. Stop the running
+stack (`docker compose down`) before invoking the one-shot form, or
+set `FORCE_RESTORE=True` to override the check.
+
 ## `app:help`
 
 Prints the list of available commands and exits. Also runs as a

--- a/docs/reference/data-volume.md
+++ b/docs/reference/data-volume.md
@@ -36,30 +36,9 @@ snapshot directly while the database is running; the `app:backup`
 artifact is the consistent, restorable form.
 
 To get the freshest possible database state in the snapshot, refresh
-`app:backup` immediately before snapshotting.
-
-(compose-volume-snapshot)=
-
-### Compose: snapshot via `tar`
-
-```bash
-docker compose exec zulip /sbin/entrypoint.sh app:backup
-docker compose run --rm -v zulip:/data -v $(pwd):/backup zulip \
-  tar czf /backup/backup.tar.gz -C /data .
-```
-
-(helm-volume-snapshot)=
-
-### Helm: `VolumeSnapshot`
-
-Kubernetes'
-[`VolumeSnapshot`](https://kubernetes.io/docs/concepts/storage/volume-snapshots/)
-CRD is the standard way to capture the chart's PVC. Most operators
-wrap `VolumeSnapshot` creation in a higher-level backup orchestrator
-that handles retention, off-cluster storage, and scheduling;
-[Velero](https://velero.io/) is the standard open-source option, and
-commercial alternatives also exist. See
-{doc}`/how-to/helm-persistence` for the chart-side details.
+`app:backup` immediately before snapshotting. See
+{doc}`/how-to/compose-backups` or {doc}`/how-to/helm-persistence` for
+the per-deployment recipes.
 
 ### Avoiding upload backups
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,7 +105,6 @@ if [ "$failure" = "1" ]; then
 fi
 
 # BEGIN appRun functions
-# === initialConfiguration ===
 prepareDirectories() {
     mkdir -p "$DATA_DIR" "$DATA_DIR/backups" "$DATA_DIR/uploads" "$DATA_DIR/certs/manual"
     if [ "${CERTIFICATES}" = "certbot" ]; then
@@ -513,8 +512,7 @@ runPostSetupScripts() {
     set -e
     echo "Post setup scripts execution succeeded."
 }
-initialConfiguration() {
-    echo "=== Begin Initial Configuration Phase ==="
+bootstrapEnvironment() {
     prepareDirectories
     local root_path="/etc/zulip"
     if [ "$LINK_SETTINGS_TO_DATA" = "True" ]; then
@@ -584,12 +582,15 @@ initialConfiguration() {
         exit 1
     fi
     autoBackupConfiguration
+}
+initialConfiguration() {
+    echo "=== Begin Initial Configuration Phase ==="
+    bootstrapEnvironment
     waitingForDatabase
     zulipMigration
     runPostSetupScripts
     echo "=== End Initial Configuration Phase ==="
 }
-# === bootstrappingEnvironment ===
 # END appRun functions
 # BEGIN app functions
 appRun() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -699,6 +699,33 @@ appRestore() {
     if supervisorctl status >/dev/null 2>&1; then
         su zulip -c "/home/zulip/deployments/current/scripts/stop-server"
         trap 'su zulip -c "/home/zulip/deployments/current/scripts/setup/flush-memcached"; su zulip -c "/home/zulip/deployments/current/scripts/start-server"' EXIT
+    else
+        # No local supervisord, so this is an ephemeral container --
+        # typically `docker compose run --rm zulip app:restore`.  If
+        # a sibling container is running Zulip services against the
+        # same database, those workers would be holding persistent
+        # connections; refuse rather than yank the schema out from
+        # under them.  `FORCE_RESTORE=True` overrides.
+        local DB_CONNECTIONS
+        DB_CONNECTIONS=$(PGPASSWORD="$PGPASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -tAc \
+            "SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid()")
+        if [ "$DB_CONNECTIONS" -gt 0 ] && [ "${FORCE_RESTORE:-False}" != "True" ]; then
+            cat >&2 <<EOF
+ERROR: $DB_CONNECTIONS active connection(s) to database "$DB_NAME" detected.
+A live Zulip stack appears to be connected to this database.  Restoring
+would drop the schema out from under those workers, leaving them with
+stale in-process state.
+
+  For an in-place restore against the running stack:
+      docker compose exec zulip /sbin/entrypoint.sh app:restore <file>
+
+  For a one-shot restore, stop the running stack first:
+      docker compose down
+
+  To override this check, set FORCE_RESTORE=True.
+EOF
+            exit 1
+        fi
     fi
 
     PGPASSWORD="$PGPASSWORD" pg_restore -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" --clean --if-exists "$DATA_DIR/backups/$BACKUP_FILE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -733,6 +733,9 @@ case "$1" in
         ;;
     app:restore)
         shift 1
+        if [ ! -f /etc/zulip/settings.py ]; then
+            initialConfiguration
+        fi
         appRestore "$@"
         ;;
     app:help)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -735,7 +735,10 @@ case "$1" in
     app:restore)
         shift 1
         if [ ! -f /etc/zulip/settings.py ]; then
-            initialConfiguration
+            # No need to migrate the empty database -- `pg_restore
+            # --clean --if-exists` will drop and recreate every
+            # object that migrate would have built.
+            bootstrapEnvironment
         fi
         appRestore "$@"
         ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -691,7 +691,17 @@ appRestore() {
     waitingForDatabase "$DB_HOST" "$DB_PORT"
     local PGPASSWORD
     PGPASSWORD="$(crudini --get /etc/zulip/zulip-secrets.conf secrets postgres_password)"
+    # Stop the Zulip application server processes around the restore
+    # so they don't serve requests against a database whose objects are
+    # mid-drop-and-recreate, and flush memcached afterwards so cached
+    # objects don't carry IDs from the discarded database.
+    if supervisorctl status >/dev/null 2>&1; then
+        su zulip -c "/home/zulip/deployments/current/scripts/stop-server"
+        trap 'su zulip -c "/home/zulip/deployments/current/scripts/setup/flush-memcached"; su zulip -c "/home/zulip/deployments/current/scripts/start-server"' EXIT
+    fi
+
     PGPASSWORD="$PGPASSWORD" pg_restore -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" --clean --if-exists "$DATA_DIR/backups/$BACKUP_FILE"
+
     echo "Restore process succeeded. Exiting."
     exit 0
 }


### PR DESCRIPTION
The compose-side recipe for taking and restoring volume snapshots was buried in `reference/data-volume.md`, leaving the the documentation inconsistent between Helm (which had a dedicated backups document) and Docker Compose (which did not).

Add `compose-backups.md` as the canonical operational home for taking and, restoring backups in Docker Compose.  Move the `(compose-volume-snapshot)=` and `(helm-volume-snapshot)=` anchors out of the reference page into the how-tos where the content now lives, leaving the reference page to describe the layout and model.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
