### PR TITLE
docs: Replace intersphinx refs to Zulip 12.1-only anchors with URLs.

### DIFF
--- a/docs/how-to/compose-backups.md
+++ b/docs/how-to/compose-backups.md
@@ -72,7 +72,7 @@ restore is in progress, and returns to healthy when it completes.
 
 For continuous off-site database backups independent of the
 volume-snapshot path, Zulip supports
-{ref}`WAL-based archiving via wal-g <zulip:wal-g>`, which streams
+[WAL-based archiving via wal-g](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#wal-g), which streams
 write-ahead logs to S3 for point-in-time recovery.
 
 ## See also

--- a/docs/how-to/compose-upgrading-from-legacy.md
+++ b/docs/how-to/compose-upgrading-from-legacy.md
@@ -13,7 +13,7 @@ If you've already migrated, you don't need this page.
 
 1. **Back up first.** This is a major upgrade and the volume layout
    changes (see below); a backup is the simplest way to make rolling
-   back tractable. See {ref}`backing up Zulip data <zulip:backups>`.
+   back tractable. See [backing up Zulip data](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#backups).
 
    ```bash
    docker compose exec zulip /sbin/entrypoint.sh app:backup

--- a/docs/how-to/helm-persistence.md
+++ b/docs/how-to/helm-persistence.md
@@ -63,7 +63,7 @@ kubectl cp zulip-0:/data/backups/ ./backups/ -c zulip
 ```
 
 To avoid backing up uploads at all, configure Zulip to use
-{ref}`S3-compatible storage <zulip:s3-backend>` as a
+[S3-compatible storage](https://zulip.readthedocs.io/en/latest/production/upload-backends.html#s3-backend) as a
 native upload backend, which keeps the PVC small.
 
 See {doc}`/reference/data-volume` for the cross-deployment backup
@@ -73,7 +73,7 @@ model.
 
 For continuous off-site database backups, independent of the
 volume-snapshot path, Zulip supports
-{ref}`WAL-based archiving via wal-g <zulip:wal-g>`,
+[WAL-based archiving via wal-g](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#wal-g),
 which streams write-ahead logs to S3 for point-in-time recovery.
 
 ## Adding a sidecar container

--- a/docs/manual/docker-compose.md
+++ b/docs/manual/docker-compose.md
@@ -23,7 +23,7 @@ container from the host.
 
 This project's `docker-compose.yml` configuration file uses [Docker managed
 volumes][volumes] to store
-{ref}`persistent Zulip data <zulip:backups>`. If you
+[persistent Zulip data](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#backups). If you
 use the Docker Compose deployment, you should make sure that Zulip's volumes
 are backed up, to ensure that Zulip's data is backed up.
 

--- a/docs/reference/data-volume.md
+++ b/docs/reference/data-volume.md
@@ -43,7 +43,7 @@ the per-deployment recipes.
 ### Avoiding upload backups
 
 Configuring Zulip to use
-{ref}`S3-compatible storage <zulip:s3-backend>` keeps
+[S3-compatible storage](https://zulip.readthedocs.io/en/latest/production/upload-backends.html#s3-backend) keeps
 user uploads out of the PVC entirely, shrinking the snapshot footprint
 and letting snapshot retention focus on configuration and database
 state.


### PR DESCRIPTION
Six refs — `zulip:wal-g`, `zulip:backups`, and `zulip:s3-backend`, each used in two places — point at anchors that exist on Zulip's main but have not yet been backported to the 12.x branch. Zulip 12.0's `objects.inv` therefore lacks them, the intersphinx mapping (pinned to the deployed Zulip version via compose.yaml's image tag) fails to resolve them, and Sphinx's `fail_on_warning: true` turns the warnings into a build failure. As a result, ReadTheDocs has been unable to publish updates to the `latest` build.

Swap the six refs for hardcoded `zulip.readthedocs.io/en/latest/` URLs so the build passes today. Revert this commit once Docker upgrades to Zulip Server 12.1, restoring version-pinned intersphinx behavior.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
