### PR TITLE
Revert "docs: Replace 12.1-only intersphinx refs with URLs."

### DIFF
--- a/docs/how-to/compose-backups.md
+++ b/docs/how-to/compose-backups.md
@@ -72,7 +72,7 @@ restore is in progress, and returns to healthy when it completes.
 
 For continuous off-site database backups independent of the
 volume-snapshot path, Zulip supports
-[WAL-based archiving via wal-g](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#wal-g), which streams
+{ref}`WAL-based archiving via wal-g <zulip:wal-g>`, which streams
 write-ahead logs to S3 for point-in-time recovery.
 
 ## See also

--- a/docs/how-to/compose-upgrading-from-legacy.md
+++ b/docs/how-to/compose-upgrading-from-legacy.md
@@ -13,7 +13,7 @@ If you've already migrated, you don't need this page.
 
 1. **Back up first.** This is a major upgrade and the volume layout
    changes (see below); a backup is the simplest way to make rolling
-   back tractable. See [backing up Zulip data](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#backups).
+   back tractable. See {ref}`backing up Zulip data <zulip:backups>`.
 
    ```bash
    docker compose exec zulip /sbin/entrypoint.sh app:backup

--- a/docs/how-to/helm-persistence.md
+++ b/docs/how-to/helm-persistence.md
@@ -63,7 +63,7 @@ kubectl cp zulip-0:/data/backups/ ./backups/ -c zulip
 ```
 
 To avoid backing up uploads at all, configure Zulip to use
-[S3-compatible storage](https://zulip.readthedocs.io/en/latest/production/upload-backends.html#s3-backend) as a
+{ref}`S3-compatible storage <zulip:s3-backend>` as a
 native upload backend, which keeps the PVC small.
 
 See {doc}`/reference/data-volume` for the cross-deployment backup
@@ -73,7 +73,7 @@ model.
 
 For continuous off-site database backups, independent of the
 volume-snapshot path, Zulip supports
-[WAL-based archiving via wal-g](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#wal-g),
+{ref}`WAL-based archiving via wal-g <zulip:wal-g>`,
 which streams write-ahead logs to S3 for point-in-time recovery.
 
 ## Adding a sidecar container

--- a/docs/manual/docker-compose.md
+++ b/docs/manual/docker-compose.md
@@ -23,7 +23,7 @@ container from the host.
 
 This project's `docker-compose.yml` configuration file uses [Docker managed
 volumes][volumes] to store
-[persistent Zulip data](https://zulip.readthedocs.io/en/latest/production/export-and-import.html#backups). If you
+{ref}`persistent Zulip data <zulip:backups>`. If you
 use the Docker Compose deployment, you should make sure that Zulip's volumes
 are backed up, to ensure that Zulip's data is backed up.
 

--- a/docs/reference/data-volume.md
+++ b/docs/reference/data-volume.md
@@ -43,7 +43,7 @@ the per-deployment recipes.
 ### Avoiding upload backups
 
 Configuring Zulip to use
-[S3-compatible storage](https://zulip.readthedocs.io/en/latest/production/upload-backends.html#s3-backend) keeps
+{ref}`S3-compatible storage <zulip:s3-backend>` keeps
 user uploads out of the PVC entirely, shrinking the snapshot footprint
 and letting snapshot retention focus on configuration and database
 state.


### PR DESCRIPTION
This should be rebased and merged once Zulip Server 12.1 has been released, and Docker Compose has bumped to 12.1 in this repo.