### PR TITLE
docs: Document remapping published ports with !override.

### DIFF
--- a/docs/how-to/compose-index.md
+++ b/docs/how-to/compose-index.md
@@ -8,6 +8,7 @@ maxdepth: 3
 compose-getting-started
 compose-settings
 compose-ssl
+compose-ports
 compose-secrets
 compose-manual-configuration
 compose-authentication

--- a/docs/how-to/compose-ports.md
+++ b/docs/how-to/compose-ports.md
@@ -1,0 +1,70 @@
+# Compose: Remapping published ports
+
+The default `compose.yaml` publishes the container's ports 25, 80, and
+443 on the same host ports. If one of those host ports is already in
+use -- for example, by a reverse proxy that listens on host port 80
+-- you will need to publish Zulip on a different host port. See
+{doc}`/reference/ports` for what each port is used for.
+
+## Why redeclaring `ports` in `compose.override.yaml` does not work
+
+Docker Compose
+[merges](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/)
+`compose.override.yaml` on top of `compose.yaml`, and by default
+appends to lists rather than replacing them. Adding a `ports:` list
+to `compose.override.yaml` therefore produces the concatenation of
+the original mappings from `compose.yaml` and the new ones, and
+Docker still tries to bind the original host ports. The result is
+an error like:
+
+```text
+Bind for 0.0.0.0:80 failed: port is already allocated
+```
+
+## Replacing the `ports` list with `!override`
+
+Docker Compose provides the
+[`!override`](https://docs.docker.com/reference/compose-file/merge/#replace-value)
+tag to replace a value entirely instead of merging it. Tag the
+`ports` list in `compose.override.yaml` with `!override` to discard
+the defaults from `compose.yaml` and use only the mappings listed
+below:
+
+```yaml
+services:
+  zulip:
+    ports: !override
+      - name: smtp
+        target: 25
+        published: 2525
+        app_protocol: smtp
+      - name: http
+        target: 80
+        published: 8080
+        app_protocol: http
+      - name: https
+        target: 443
+        published: 8443
+        app_protocol: https
+```
+
+With this override, Docker publishes only the listed ports and
+leaves host port 80 free for the reverse proxy.
+
+If you do not need a port published on the host at all -- for
+example, port 25 when you are not using the
+{doc}`incoming email gateway <compose-incoming-email>` -- omit it
+from the `!override` list.
+
+The related
+[`!reset`](https://docs.docker.com/reference/compose-file/merge/#reset-value)
+tag removes a value entirely rather than replacing it; see
+{doc}`compose-existing-services` for an example that uses it to
+drop an inherited service.
+
+## See also
+
+- {doc}`/reference/ports`
+- {doc}`compose-ssl`
+- {doc}`compose-incoming-email`
+- [Reference syntax for merging Compose files](https://docs.docker.com/reference/compose-file/merge/)

--- a/docs/how-to/compose-ssl.md
+++ b/docs/how-to/compose-ssl.md
@@ -164,6 +164,10 @@ know which `X-Forwarded-*` headers to trust.
    {doc}`Zulip's guide to reverse proxies <zulip:production/reverse-proxies>`
    for details.
 
+1. If the reverse proxy runs on the same host and uses port 80 or 443
+   itself, you will need to publish Zulip on different host ports;
+   see {doc}`compose-ports`.
+
 ## See also
 
 - [Merging Compose files](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/)

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -54,5 +54,6 @@ the StatefulSet pod.
 
 - {doc}`environment-vars`
 - {doc}`/how-to/compose-ssl`
+- {doc}`/how-to/compose-ports`
 - {doc}`/how-to/compose-incoming-email`
 - {doc}`/how-to/helm-ssl`


### PR DESCRIPTION
Users behind a reverse proxy on the same host commonly need to publish Zulip on alternate host ports. Re-declaring the `ports` list in `compose.override.yaml` does not work, because Docker Compose appends list values during merge rather than replacing them, and bind on the default ports still fails. Document the `!override` tag from the Compose merge reference as the way to replace the list entirely.

Cross-link the new page from the reverse-proxy section of `compose-ssl.md` and from the ports reference, where users hitting the "port is already allocated" error are most likely to look first.

Fixes: #649.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
