### PR TITLE
docs: Add a guide for using your own Ingress solution.

### DIFF
--- a/docs/how-to/helm-index.md
+++ b/docs/how-to/helm-index.md
@@ -8,6 +8,7 @@ maxdepth: 3
 helm-getting-started
 helm-settings
 helm-ssl
+helm-ingress
 helm-proxy-trust
 helm-existing-services
 helm-upgrading

--- a/docs/how-to/helm-ingress.md
+++ b/docs/how-to/helm-ingress.md
@@ -1,0 +1,69 @@
+# Helm: Using your own Ingress solution
+
+The Helm chart does not require any particular Ingress solution. The
+Ingress resource it can create (`ingress.enabled`, disabled by
+default) is a convenience, not a requirement; any Ingress controller,
+Gateway API implementation, service mesh, or cloud load balancer
+works, as long as it fulfills the small contract below.
+
+## What Zulip needs from the proxy in front of it
+
+Whatever routes traffic to Zulip must:
+
+1. **Route HTTP to the chart's Service.** By default, the Service
+   listens on port 80 and the Zulip pod serves unencrypted HTTP; see
+   {doc}`helm-ssl`.
+
+1. **Terminate TLS, and set `X-Forwarded-Proto`.** Zulip requires
+   HTTPS in production. The proxy must set the `X-Forwarded-Proto`
+   header to `https`, overriding any client-supplied value; Django
+   uses it for CSRF checks and secure cookies.
+
+1. **Set `X-Forwarded-For`, and be listed in `LOADBALANCER_IPS`.**
+   Zulip only trusts `X-Forwarded-*` headers from source addresses
+   listed in `LOADBALANCER_IPS`, so that clients cannot spoof their
+   IP addresses to evade rate limiting and audit logging. See
+   {doc}`helm-proxy-trust`.
+
+1. **Pass the client's `Host:` header through unchanged**, and route
+   the hostname in `SETTING_EXTERNAL_HOST` (and any realm subdomains
+   of it) to the Service.
+
+1. **Permit long-lived requests.** Zulip delivers real-time events
+   over HTTP long-polling, so idle/read timeouts on the route must be
+   significantly longer than 60 seconds (`proxy_read_timeout` in
+   nginx terms), and response buffering should be disabled if your
+   proxy buffers by default.
+
+These are the same requirements as for any reverse proxy in front of
+a standalone Zulip server; see
+{doc}`zulip:production/reverse-proxies`.
+
+## What stays Zulip configuration
+
+Two settings remain with Zulip no matter which Ingress solution you
+choose, because they are application configuration, not proxy
+configuration:
+
+- `SETTING_EXTERNAL_HOST` is the canonical hostname users reach the
+  server at. Zulip uses it to build absolute URLs in contexts where
+  there is no request to derive a hostname from -- invitation and
+  notification emails, and API and mobile-app server URLs -- and to
+  validate the `Host:` header of incoming requests (Django's
+  `ALLOWED_HOSTS`), which protects against Host-header attacks such
+  as password-reset link poisoning. It cannot safely be derived from
+  the request.
+
+- `LOADBALANCER_IPS` tells Zulip which source addresses are your
+  proxy layer, and hence when to believe `X-Forwarded-*` headers.
+
+Both are statements of fact about the network the administrator
+built, which Zulip cannot discover on its own; beyond them, DNS, TLS,
+routing, and traffic policy are entirely up to your Ingress layer.
+
+## See also
+
+- {doc}`helm-ssl`
+- {doc}`helm-proxy-trust`
+- {doc}`helm-getting-started`
+- {doc}`zulip:production/reverse-proxies`

--- a/docs/how-to/helm-proxy-trust.md
+++ b/docs/how-to/helm-proxy-trust.md
@@ -52,5 +52,6 @@ opt back in, but {ref}`loadbalancer-ips` is the recommended approach.
 - {ref}`loadbalancer-ips`
 - {ref}`trust-gateway-ip`
 - {doc}`zulip:production/reverse-proxies`
+- {doc}`helm-ingress`
 - {doc}`helm-ssl`
 - {doc}`helm-settings`

--- a/docs/how-to/helm-ssl.md
+++ b/docs/how-to/helm-ssl.md
@@ -138,6 +138,7 @@ switches from `http` (port 80) to `https` (port 443) automatically.
 
 - [Kubernetes Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 - [cert-manager documentation](https://cert-manager.io/docs/)
+- {doc}`helm-ingress`
 - {doc}`helm-proxy-trust`
 - {doc}`helm-settings`
 - {doc}`helm-getting-started`


### PR DESCRIPTION
Kubernetes administrators choosing between Ingress controllers, Gateway API implementations, and service meshes have asked what Zulip requires from the layer in front of it, and which parts of the proxy-adjacent configuration cannot be delegated to it.

Document the contract in one place: route HTTP to the Service, terminate TLS and set X-Forwarded-Proto, set X-Forwarded-For from an address in LOADBALANCER_IPS, pass the Host header through, and permit long-polling.  Explain why EXTERNAL_HOST and LOADBALANCER_IPS remain application configuration regardless of the Ingress solution chosen.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
