### PR TITLE
docker: Create the /.dockerenv marker for non-Docker runtimes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,12 @@ RUN \
     /root/zulip/scripts/setup/install --hostname="docker-zulip.local" --email="docker-zulip" \
       --puppet-classes="zulip::profile::docker" --postgresql-version=14 && \
     rm -f /etc/zulip/zulip-secrets.conf /etc/zulip/settings.py && \
+    # Zulip checks for /.dockerenv (as RUNNING_IN_DOCKER) to tailor
+    # error messages to this image's SETTING_* environment variables.
+    # The Docker engine creates that marker at runtime, but Kubernetes
+    # container runtimes (containerd, CRI-O) do not; bake it into the
+    # image so detection does not depend on the container runtime.
+    touch /.dockerenv && \
     apt-get -qq autoremove --purge -y && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Zulip detects that it is running in this image by checking for /.dockerenv (RUNNING_IN_DOCKER, used since zulip/zulip@b869cb29e0), and uses that to point configuration error messages at the SETTING_* environment variables, rather than at /etc/zulip/settings.py.

The Docker engine creates /.dockerenv at runtime, but Kubernetes container runtimes (containerd, CRI-O) do not -- so precisely the deployments whose users are furthest from /etc/zulip/settings.py got the misleading bare-metal error messages.

Bake the marker into the image, so detection does not depend on the container runtime.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
