### PR TITLE
helm: Support configuring the RabbitMQ vhost for external servers.

### DIFF
--- a/docs/how-to/helm-existing-services.md
+++ b/docs/how-to/helm-existing-services.md
@@ -44,7 +44,11 @@ externalRabbitmq:
   port: 5672
   user: zulip
   password: your-rabbitmq-password
+  # vhost: "/"
 ```
+
+Set `vhost` if Zulip should use a non-default RabbitMQ
+[virtual host](https://www.rabbitmq.com/docs/vhosts); it defaults to `/`.
 
 ## Using an external Memcached server
 

--- a/helm/zulip/ci/external-services-values.yaml
+++ b/helm/zulip/ci/external-services-values.yaml
@@ -28,6 +28,7 @@ externalRabbitmq:
   port: 5672
   user: zulip
   password: external-rabbitmq-password
+  vhost: zulip-vhost
 
 externalMemcached:
   host: memcached.example.com

--- a/helm/zulip/templates/_helpers.tpl
+++ b/helm/zulip/templates/_helpers.tpl
@@ -136,6 +136,10 @@ include all env variables for Zulip pods
 - name: SETTING_RABBITMQ_USERNAME
   value: {{ .Values.externalRabbitmq.user | quote }}
 {{- end }}
+{{- if .Values.externalRabbitmq.vhost }}
+- name: SETTING_RABBITMQ_VHOST
+  value: {{ .Values.externalRabbitmq.vhost | quote }}
+{{- end }}
 {{- end }}
 
 {{/* --- Memcached --- */}}

--- a/helm/zulip/tests/statefulset_test.yaml
+++ b/helm/zulip/tests/statefulset_test.yaml
@@ -75,6 +75,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SETTING_RABBITMQ_VHOST
+            value: zulip-vhost
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: SETTING_MEMCACHED_LOCATION
             value: "memcached.example.com:11211"
       - contains:

--- a/helm/zulip/values.schema.json
+++ b/helm/zulip/values.schema.json
@@ -447,6 +447,10 @@
           "type": "string",
           "description": "RabbitMQ username."
         },
+        "vhost": {
+          "type": "string",
+          "description": "RabbitMQ virtual host. Defaults to \"/\" if unset."
+        },
         "password": {
           "$ref": "#/definitions/scalarOrValueFrom",
           "description": "RabbitMQ password. Supports scalar values and valueFrom maps."

--- a/helm/zulip/values.yaml
+++ b/helm/zulip/values.yaml
@@ -278,6 +278,8 @@ externalRabbitmq:
   user: "zulip"
   ## password supports both scalar values and valueFrom maps.
   # password: ""
+  ## The RabbitMQ "virtual host" to use; defaults to "/" if unset.
+  # vhost: "/"
 
 ## External Memcached configuration.
 ## Used when memcached.enabled is set to false.


### PR DESCRIPTION
Zulip can connect to a RabbitMQ "virtual host" other than the default "/" via the RABBITMQ_VHOST setting, and the entrypoint already passes any SETTING_RABBITMQ_VHOST through to settings.py.  But the Helm chart exposed externalRabbitmq as structured host/port/user/password keys with no vhost, so a user pointing Zulip at an existing RabbitMQ server had no discoverable way to set it: externalRabbitmq.vhost (the natural guess) was silently ignored, and the option was documented in neither the external-services nor the settings how-to.

Add externalRabbitmq.vhost, emitting SETTING_RABBITMQ_VHOST only when set so the default "/" behavior is unchanged, and document it in the external-services how-to.  Allow the property in the values schema and exercise it in the external-services unittest values, asserting the env var renders.

This is scoped to external RabbitMQ; the bundled Bitnami subchart uses the default "/" vhost.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
