### PR TITLE
ci: Functionally test the Helm chart with subchart persistence enabled.

### DIFF
--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -122,6 +122,12 @@ jobs:
     needs:
       - build
       - helm-lint
+    strategy:
+      fail-fast: false
+      matrix:
+        values:
+          - simple-values.yaml
+          - persistence-values.yaml
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -155,7 +161,7 @@ jobs:
       - name: Install chart
         run: |
           helm install zulip helm/zulip/ \
-            -f helm/zulip/ci/simple-values.yaml \
+            -f "helm/zulip/ci/${{ matrix.values }}" \
             --set image.tag=pr-${{ github.event.pull_request.number }} \
             --wait --timeout 10m
 

--- a/helm/zulip/ci/persistence-values.yaml
+++ b/helm/zulip/ci/persistence-values.yaml
@@ -1,0 +1,42 @@
+---
+# Test: Bundled subcharts deployed with persistence enabled, so the
+# functional suite exercises the PVC-provisioning and volume-permission
+# startup path that the default emptyDir configuration never covers.
+#
+# Mirrors simple-values.yaml (same SETTING_EXTERNAL_HOST, so ci/test.sh
+# works unchanged) but turns on persistence for the subcharts that
+# default to emptyDir in this chart's values.yaml.  PostgreSQL and the
+# Zulip pod itself are already persistent by default.
+image:
+  pullPolicy: Never
+  repository: zulip/zulip-server
+  # CI will pass tag: of the PR
+
+zulip:
+  environment:
+    SECRETS_secret_key: set-secure-zulip-secret-key
+    SETTING_ZULIP_ADMINISTRATOR: "admin@example.net"
+    SETTING_EXTERNAL_HOST: zulip.example.net
+
+memcached:
+  auth:
+    password: set-secure-memcached-password
+
+rabbitmq:
+  auth:
+    password: set-secure-rabbitmq-password
+    erlangCookie: set-secure-cookie-password
+  persistence:
+    enabled: true
+
+redis:
+  auth:
+    password: set-secure-redis-password
+  master:
+    persistence:
+      enabled: true
+
+postgresql:
+  auth:
+    postgresPassword: set-secure-pg-postgres-password
+    password: set-secure-pg-zulip-password


### PR DESCRIPTION
The KIND functional test only ever deployed simple-values.yaml, in which the bundled RabbitMQ and Redis run on emptyDir (this chart's values.yaml disables their persistence by default).  That leaves the PVC-provisioning and volume-permission startup path of those subcharts completely untested at runtime, even though persistence is the configuration real deployments use.

Add a persistence-values.yaml scenario that enables persistence for the bundled RabbitMQ and Redis (PostgreSQL and the Zulip pod are already persistent by default), and run the helm-test job as a matrix over both simple and persistence values so each is installed and exercised by the end-to-end suite.  fail-fast is disabled so a failure in one scenario does not mask the result of the other.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
