### PR TITLE
docs: Note when the bundled RabbitMQ may fail to start on Helm.

### DIFF
--- a/docs/how-to/helm-existing-services.md
+++ b/docs/how-to/helm-existing-services.md
@@ -33,6 +33,8 @@ pre-existing external services instead.
 1. Create the `zulip` database and user on your external server before
    installing the chart.
 
+(helm-external-rabbitmq)=
+
 ## Using an external RabbitMQ server
 
 ```yaml

--- a/docs/how-to/helm-getting-started.md
+++ b/docs/how-to/helm-getting-started.md
@@ -55,6 +55,17 @@
    kubectl get pods -w
    ```
 
+   ```{note}
+   The bundled RabbitMQ runs as a Kubernetes-native clustered deployment:
+   each node queries the Kubernetes API (through its ServiceAccount RBAC)
+   for its peers and resolves its own `*.svc.cluster.local` headless DNS
+   name. On hardened clusters this can stop it from starting — for example
+   a default-deny NetworkPolicy blocking the API server, restricted RBAC, a
+   non-default cluster domain, or a memory limit too low for the Erlang VM.
+   If the RabbitMQ pod never becomes ready, point Zulip at an
+   {ref}`external RabbitMQ server <helm-external-rabbitmq>` instead.
+   ```
+
 1. Once the pod is ready, generate a link to create your first organization:
 
    ```bash


### PR DESCRIPTION
The bundled RabbitMQ subchart is a Kubernetes-native clustered deployment that, at startup, queries the Kubernetes API for its peers and resolves its own headless-service DNS name.  On hardened clusters (default-deny NetworkPolicies, restricted RBAC, a non-default cluster domain, or a memory limit too low for the Erlang VM) it can fail to start, with none of these dependencies present in a stock cluster like the one our CI exercises.

Place this note at the watch-the-pods step in the getting-started guide, where a user staring at a RabbitMQ pod that will not become ready will find it.  The note links to the external-RabbitMQ section, which gains an anchor as the link target, as the robust way to avoid these Kubernetes-specific startup dependencies.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR changes output, always include screenshots or code blocks to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**How did you test this PR?**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
